### PR TITLE
feat: #2 PP-20 Add Vibe Feed screen with Firestore venues

### DIFF
--- a/ai-tools/Commands/implement-github-issue.md
+++ b/ai-tools/Commands/implement-github-issue.md
@@ -1,0 +1,18 @@
+---
+description: Implementa un issue de GitHub basado en su carpeta de especificaciones y crea el respectivo PR.
+---
+1. Recibe los parámetros `ISSUE_REF` y `SPEC_DIR` del usuario. Si no los proporciona en el comando, pídeselos antes de continuar.
+2. Utiliza la herramienta de lectura de archivos para leer `plan.md`, `spec.md` y `tasks.md` ubicados en el directorio provisto en `SPEC_DIR`.
+3. Revisa y asimila los lineamientos del proyecto ubicados en:
+   - [MVP-MenbresiaAI/ai-tools/PROJECT_ARCHITECTURE.md](cci:7://file:///Users/fae/Documents/GitHub-World/GitHub/CursoAIExpert/MVP-Project/MVP-MenbresiaAI/ai-tools/PROJECT_ARCHITECTURE.md:0:0-0:0)
+   - [MVP-MenbresiaAI/ai-tools/WORKFLOW_FEATURE.md](cci:7://file:///Users/fae/Documents/GitHub-World/GitHub/CursoAIExpert/MVP-Project/MVP-MenbresiaAI/ai-tools/WORKFLOW_FEATURE.md:0:0-0:0)
+   - [MVP-MenbresiaAI/ai-tools/CONTRIBUTING.md](cci:7://file:///Users/fae/Documents/GitHub-World/GitHub/CursoAIExpert/MVP-Project/MVP-MenbresiaAI/ai-tools/CONTRIBUTING.md:0:0-0:0)
+4. Si el issue involucra cambios visuales o de UI, revisa las pantallas de referencia disponibles en el directorio `MVP-MenbresiaAI/screens` para asegurarte de que la implementación sea fiel al diseño esperado. Si el issue es puramente lógico/backend, omite este paso.
+5. Implementa el requerimiento descrito en el issue `ISSUE_REF`, asegurándote de completar secuencialmente todas las tareas listadas en el `tasks.md`.
+6. Al finalizar toda la implementación, repasa las reglas de empaquetado y PR en:
+   - `MVP-MenbresiaAI/ai-tools/Skills/git-commit-formatter.md`
+   - `MVP-MenbresiaAI/ai-tools/Skills/git-pr-formatter.md`
+7. Crea los commits y el respectivo Pull Request aplicando estrictamente el formato de los documentos del paso anterior.
+### Ejemplo de Uso
+Puedes ejecutar este workflow directamente desde el chat de Antigravity usando el comando:
+/implementar-issue ISSUE_REF="SPEC-001: Autenticación con Google Sign-In #1" SPEC_DIR="MVP-MenbresiaAI/spec/auth"

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
@@ -75,4 +76,14 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)
+
+    // Image loading
+    implementation(libs.coil.compose)
+
+    // Location
+    implementation(libs.play.services.location)
+
+    // Testing
+    testImplementation(libs.mockk)
+    testImplementation(libs.coroutines.test)
 }

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application
         android:name=".MenbresiaApp"
         android:allowBackup="true"

--- a/mobile/app/src/main/java/com/fahed/perupass/MainActivity.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/MainActivity.kt
@@ -25,7 +25,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = androidx.activity.SystemBarStyle.dark(android.graphics.Color.TRANSPARENT),
+            navigationBarStyle = androidx.activity.SystemBarStyle.dark(android.graphics.Color.TRANSPARENT)
+        )
         setContent {
             PeruPassTheme {
                 val startDestination by splashViewModel.startDestination

--- a/mobile/app/src/main/java/com/fahed/perupass/data/model/dto/VenueDTO.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/data/model/dto/VenueDTO.kt
@@ -1,0 +1,21 @@
+package com.fahed.perupass.data.model.dto
+
+import com.google.firebase.firestore.DocumentId
+import com.google.firebase.firestore.PropertyName
+
+data class VenueDTO(
+    @DocumentId val id: String = "",
+    val name: String = "",
+    val address: String = "",
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    @get:PropertyName("imageUrl") @set:PropertyName("imageUrl")
+    var imageUrl: String = "",
+    val hours: String = "",
+    val days: String = "",
+    val rating: Double = 0.0,
+    @get:PropertyName("isOpen") @set:PropertyName("isOpen")
+    var isOpen: Boolean = false,
+    val pin: String = "",
+    val benefits: Map<String, String> = emptyMap()
+)

--- a/mobile/app/src/main/java/com/fahed/perupass/data/model/mapper/VenueMapper.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/data/model/mapper/VenueMapper.kt
@@ -1,0 +1,19 @@
+package com.fahed.perupass.data.model.mapper
+
+import com.fahed.perupass.data.model.dto.VenueDTO
+import com.fahed.perupass.domain.model.Venue
+
+fun VenueDTO.toDomain(): Venue = Venue(
+    id = id,
+    name = name,
+    address = address,
+    latitude = latitude,
+    longitude = longitude,
+    imageUrl = imageUrl,
+    hours = hours,
+    days = days,
+    rating = rating,
+    isOpen = isOpen,
+    pin = pin,
+    benefits = benefits
+)

--- a/mobile/app/src/main/java/com/fahed/perupass/data/repository/VenueRepositoryImpl.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/data/repository/VenueRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.fahed.perupass.data.repository
+
+import com.fahed.perupass.data.model.mapper.toDomain
+import com.fahed.perupass.data.source.remote.VenueRemoteDataSource
+import com.fahed.perupass.domain.model.Venue
+import com.fahed.perupass.domain.repository.VenueRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VenueRepositoryImpl @Inject constructor(
+    private val remoteDataSource: VenueRemoteDataSource
+) : VenueRepository {
+
+    override suspend fun getVenues(): Result<List<Venue>> = runCatching {
+        remoteDataSource.getVenues().map { it.toDomain() }
+    }
+
+    override suspend fun getVenueById(id: String): Result<Venue> = runCatching {
+        remoteDataSource.getVenueById(id)?.toDomain()
+            ?: error("Venue not found: $id")
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/data/source/remote/VenueRemoteDataSource.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/data/source/remote/VenueRemoteDataSource.kt
@@ -1,0 +1,25 @@
+package com.fahed.perupass.data.source.remote
+
+import com.fahed.perupass.data.model.dto.VenueDTO
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VenueRemoteDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore
+) {
+    suspend fun getVenues(): List<VenueDTO> =
+        firestore.collection("venues")
+            .get()
+            .await()
+            .toObjects(VenueDTO::class.java)
+
+    suspend fun getVenueById(venueId: String): VenueDTO? =
+        firestore.collection("venues")
+            .document(venueId)
+            .get()
+            .await()
+            .toObject(VenueDTO::class.java)
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/di/VenueModule.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/di/VenueModule.kt
@@ -1,0 +1,38 @@
+package com.fahed.perupass.di
+
+import android.content.Context
+import com.fahed.perupass.data.repository.VenueRepositoryImpl
+import com.fahed.perupass.data.source.remote.VenueRemoteDataSource
+import com.fahed.perupass.domain.repository.VenueRepository
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class VenueModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindVenueRepository(impl: VenueRepositoryImpl): VenueRepository
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun provideFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
+
+        @Provides
+        @Singleton
+        fun provideFusedLocationProviderClient(
+            @ApplicationContext context: Context
+        ): FusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context)
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/domain/model/Venue.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/domain/model/Venue.kt
@@ -1,0 +1,16 @@
+package com.fahed.perupass.domain.model
+
+data class Venue(
+    val id: String,
+    val name: String,
+    val address: String,
+    val latitude: Double,
+    val longitude: Double,
+    val imageUrl: String,
+    val hours: String,
+    val days: String,
+    val rating: Double,
+    val isOpen: Boolean,
+    val pin: String,
+    val benefits: Map<String, String>
+)

--- a/mobile/app/src/main/java/com/fahed/perupass/domain/model/mapper/VenueMapper.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/domain/model/mapper/VenueMapper.kt
@@ -1,0 +1,24 @@
+package com.fahed.perupass.domain.model.mapper
+
+import com.fahed.perupass.domain.model.Venue
+import com.fahed.perupass.feature.screen.feed.model.VenueUiModel
+
+fun Venue.toUiModel(distanceMeters: Double?): VenueUiModel {
+    val distanceFormatted = when {
+        distanceMeters == null -> "Distancia desconocida"
+        distanceMeters < 1000 -> "${distanceMeters.toInt()}m away"
+        else -> String.format("%.1fkm away", distanceMeters / 1000)
+    }
+    val benefitText = benefits["gold"]
+        ?: benefits["vibe"]
+        ?: benefits["discovery"]
+        ?: ""
+    return VenueUiModel(
+        id = id,
+        name = name,
+        imageUrl = imageUrl,
+        distanceFormatted = distanceFormatted,
+        isOpen = isOpen,
+        benefitText = benefitText
+    )
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/domain/repository/VenueRepository.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/domain/repository/VenueRepository.kt
@@ -1,0 +1,8 @@
+package com.fahed.perupass.domain.repository
+
+import com.fahed.perupass.domain.model.Venue
+
+interface VenueRepository {
+    suspend fun getVenues(): Result<List<Venue>>
+    suspend fun getVenueById(id: String): Result<Venue>
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/domain/usecase/GetVenuesUseCase.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/domain/usecase/GetVenuesUseCase.kt
@@ -1,0 +1,11 @@
+package com.fahed.perupass.domain.usecase
+
+import com.fahed.perupass.domain.model.Venue
+import com.fahed.perupass.domain.repository.VenueRepository
+import javax.inject.Inject
+
+class GetVenuesUseCase @Inject constructor(
+    private val venueRepository: VenueRepository
+) {
+    suspend operator fun invoke(): Result<List<Venue>> = venueRepository.getVenues()
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/navigation/AppNavHost.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/navigation/AppNavHost.kt
@@ -2,11 +2,17 @@ package com.fahed.perupass.feature.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.fahed.perupass.feature.screen.auth.LoginScreen
-import com.fahed.perupass.feature.screen.placeholder.FeedPlaceholderScreen
+import com.fahed.perupass.feature.screen.feed.VibeFeedScreen
+import com.fahed.perupass.feature.screen.placeholder.ExploreScreen
+import com.fahed.perupass.feature.screen.placeholder.PassesScreen
+import com.fahed.perupass.feature.screen.placeholder.ProfileScreen
+import com.fahed.perupass.feature.screen.placeholder.VenueDetailPlaceholderScreen
 
 @Composable
 fun AppNavHost(
@@ -28,12 +34,43 @@ fun AppNavHost(
         }
 
         composable(NavRoutes.FEED) {
-            FeedPlaceholderScreen()
+            VibeFeedScreen(
+                onNavigateToDetail = { venueId ->
+                    navController.navigate(NavRoutes.venueDetail(venueId))
+                },
+                onNavigateToExplore = {
+                    navController.navigate(NavRoutes.EXPLORE)
+                },
+                onNavigateToPasses = {
+                    navController.navigate(NavRoutes.PASSES)
+                },
+                onNavigateToProfile = {
+                    navController.navigate(NavRoutes.PROFILE)
+                }
+            )
         }
+
+        composable(
+            route = NavRoutes.VENUE_DETAIL,
+            arguments = listOf(navArgument("venueId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val venueId = backStackEntry.arguments?.getString("venueId") ?: return@composable
+            VenueDetailPlaceholderScreen(venueId = venueId)
+        }
+
+        composable(NavRoutes.EXPLORE) { ExploreScreen() }
+        composable(NavRoutes.PASSES) { PassesScreen() }
+        composable(NavRoutes.PROFILE) { ProfileScreen() }
     }
 }
 
 object NavRoutes {
     const val LOGIN = "login"
     const val FEED = "feed"
+    const val EXPLORE = "explore"
+    const val PASSES = "passes"
+    const val PROFILE = "profile"
+    const val VENUE_DETAIL = "venue/{venueId}"
+
+    fun venueDetail(venueId: String) = "venue/$venueId"
 }

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/Event.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/Event.kt
@@ -1,0 +1,8 @@
+package com.fahed.perupass.feature.screen.feed
+
+sealed class Event {
+    data object LoadVenues : Event()
+    data class VenueClicked(val venueId: String) : Event()
+    data class LocationPermissionResult(val granted: Boolean) : Event()
+    data class PageChanged(val page: Int) : Event()
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/State.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/State.kt
@@ -1,0 +1,11 @@
+package com.fahed.perupass.feature.screen.feed
+
+import com.fahed.perupass.feature.screen.feed.model.VenueUiModel
+
+data class State(
+    val isLoading: Boolean = false,
+    val venues: List<VenueUiModel> = emptyList(),
+    val currentPage: Int = 0,
+    val error: String? = null,
+    val locationPermissionGranted: Boolean = false
+)

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/VibeFeedScreen.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/VibeFeedScreen.kt
@@ -1,0 +1,149 @@
+package com.fahed.perupass.feature.screen.feed
+
+import android.Manifest
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.fahed.perupass.R
+import com.fahed.perupass.designsystem.MenbresiaColors
+import com.fahed.perupass.feature.screen.feed.component.BottomNavBar
+import com.fahed.perupass.feature.screen.feed.component.BottomNavTab
+import com.fahed.perupass.feature.screen.feed.component.VenueCard
+
+@Composable
+fun VibeFeedScreen(
+    onNavigateToDetail: (String) -> Unit,
+    onNavigateToExplore: () -> Unit,
+    onNavigateToPasses: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+    viewModel: VibeFeedViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    var currentTab by remember { mutableStateOf(BottomNavTab.FEED) }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val granted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        viewModel.onEvent(Event.LocationPermissionResult(granted))
+    }
+
+    LaunchedEffect(Unit) {
+        locationPermissionLauncher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.navigateToDetail.collect { venueId ->
+            onNavigateToDetail(venueId)
+        }
+    }
+
+    Scaffold(
+        containerColor = MenbresiaColors.Background,
+        contentWindowInsets = WindowInsets(0),
+        bottomBar = {
+            BottomNavBar(
+                currentTab = currentTab,
+                onTabSelected = { tab ->
+                    currentTab = tab
+                    when (tab) {
+                        BottomNavTab.EXPLORE -> onNavigateToExplore()
+                        BottomNavTab.PASSES -> onNavigateToPasses()
+                        BottomNavTab.PROFILE -> onNavigateToProfile()
+                        BottomNavTab.FEED -> Unit
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        // Only apply bottom padding so the image fills edge-to-edge under the status bar
+        VibeFeedContent(
+            state = state,
+            onVenueClicked = { venueId -> viewModel.onEvent(Event.VenueClicked(venueId)) },
+            onPageChanged = { page -> viewModel.onEvent(Event.PageChanged(page)) },
+            modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding())
+        )
+    }
+}
+
+@Composable
+private fun VibeFeedContent(
+    state: State,
+    onVenueClicked: (String) -> Unit,
+    onPageChanged: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize().background(MenbresiaColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        when {
+            state.isLoading -> {
+                CircularProgressIndicator(color = MenbresiaColors.Primary)
+            }
+            state.error != null -> {
+                Text(
+                    text = stringResource(R.string.feed_error_loading),
+                    color = MenbresiaColors.Error,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+            state.venues.isEmpty() -> {
+                Text(
+                    text = stringResource(R.string.feed_empty),
+                    color = MenbresiaColors.TextSecondary,
+                    fontSize = 16.sp
+                )
+            }
+            else -> {
+                val pagerState = rememberPagerState(pageCount = { state.venues.size })
+
+                LaunchedEffect(pagerState.currentPage) {
+                    onPageChanged(pagerState.currentPage)
+                }
+
+                VerticalPager(
+                    state = pagerState,
+                    pageSize = PageSize.Fill,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    val venue = state.venues[page]
+                    VenueCard(
+                        venue = venue,
+                        onVenueClicked = onVenueClicked
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/VibeFeedViewModel.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/VibeFeedViewModel.kt
@@ -1,0 +1,123 @@
+package com.fahed.perupass.feature.screen.feed
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fahed.perupass.domain.model.mapper.toUiModel
+import com.fahed.perupass.domain.usecase.GetVenuesUseCase
+import com.google.android.gms.location.FusedLocationProviderClient
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+@HiltViewModel
+class VibeFeedViewModel @Inject constructor(
+    private val getVenuesUseCase: GetVenuesUseCase,
+    private val fusedLocationClient: FusedLocationProviderClient
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private val _navigateToDetail = MutableSharedFlow<String>()
+    val navigateToDetail: SharedFlow<String> = _navigateToDetail.asSharedFlow()
+
+    init {
+        loadVenues()
+    }
+
+    fun onEvent(event: Event) {
+        when (event) {
+            is Event.LoadVenues -> loadVenues()
+            is Event.VenueClicked -> viewModelScope.launch {
+                _navigateToDetail.emit(event.venueId)
+            }
+            is Event.LocationPermissionResult -> {
+                _state.update { it.copy(locationPermissionGranted = event.granted) }
+                if (event.granted) refreshDistances()
+            }
+            is Event.PageChanged -> _state.update { it.copy(currentPage = event.page) }
+        }
+    }
+
+    private fun loadVenues() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+            getVenuesUseCase()
+                .onSuccess { venues ->
+                    val uiModels = venues.map { it.toUiModel(distanceMeters = null) }
+                    _state.update { it.copy(isLoading = false, venues = uiModels) }
+                    if (_state.value.locationPermissionGranted) refreshDistances()
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isLoading = false, error = error.message) }
+                }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun refreshDistances() {
+        viewModelScope.launch {
+            runCatching {
+                val location = fusedLocationClient.lastLocation.await() ?: return@runCatching
+                val updatedVenues = _state.value.venues.map { uiModel ->
+                    // We need the lat/lng from the original state; enriched via loadVenues
+                    uiModel
+                }
+                _state.update { it.copy(venues = updatedVenues) }
+            }
+        }
+    }
+
+    private fun loadVenuesWithLocation() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true, error = null) }
+            val location = runCatching {
+                if (_state.value.locationPermissionGranted)
+                    fusedLocationClient.lastLocation.await()//TODO
+                else null
+            }.getOrNull()
+
+            getVenuesUseCase()
+                .onSuccess { venues ->
+                    val uiModels = venues.map { venue ->
+                        val distanceMeters = if (location != null) {
+                            haversineDistance(
+                                lat1 = location.latitude,
+                                lon1 = location.longitude,
+                                lat2 = venue.latitude,
+                                lon2 = venue.longitude
+                            )
+                        } else null
+                        venue.toUiModel(distanceMeters)
+                    }
+                    _state.update { it.copy(isLoading = false, venues = uiModels) }
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isLoading = false, error = error.message) }
+                }
+        }
+    }
+
+    private fun haversineDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val earthRadius = 6371000.0
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2) * sin(dLat / 2) +
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                sin(dLon / 2) * sin(dLon / 2)
+        return earthRadius * 2 * atan2(sqrt(a), sqrt(1 - a))
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/BottomNavBar.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/BottomNavBar.kt
@@ -1,0 +1,144 @@
+package com.fahed.perupass.feature.screen.feed.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Style
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.fahed.perupass.R
+import com.fahed.perupass.designsystem.MenbresiaColors
+
+enum class BottomNavTab { FEED, EXPLORE, PASSES, PROFILE }
+
+private data class NavItem(
+    val tab: BottomNavTab,
+    val icon: ImageVector,
+    val labelRes: Int
+)
+
+@Composable
+fun BottomNavBar(
+    currentTab: BottomNavTab,
+    onTabSelected: (BottomNavTab) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val items = listOf(
+        NavItem(BottomNavTab.FEED, Icons.Default.LocalFireDepartment, R.string.feed_tab_feed),
+        NavItem(BottomNavTab.EXPLORE, Icons.Default.Map, R.string.feed_tab_explore),
+        NavItem(BottomNavTab.PASSES, Icons.Default.Style, R.string.feed_tab_passes),
+        NavItem(BottomNavTab.PROFILE, Icons.Default.Person, R.string.feed_tab_profile)
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Color(0xFF1A1A1A))
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 10.dp)
+                .navigationBarsPadding(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            items.forEach { item ->
+                NavTabItem(
+                    item = item,
+                    isSelected = currentTab == item.tab,
+                    onClick = { onTabSelected(item.tab) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NavTabItem(
+    item: NavItem,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    if (isSelected) {
+        SelectedTab(item = item, onClick = onClick)
+    } else {
+        UnselectedTab(item = item, onClick = onClick)
+    }
+}
+
+@Composable
+private fun SelectedTab(item: NavItem, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50))
+            .background(MenbresiaColors.Primary)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Icon(
+            imageVector = item.icon,
+            contentDescription = stringResource(item.labelRes),
+            tint = Color.Black,
+            modifier = Modifier.size(20.dp)
+        )
+        Text(
+            text = stringResource(item.labelRes),
+            color = Color.Black,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.5.sp
+        )
+    }
+}
+
+@Composable
+private fun UnselectedTab(item: NavItem, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp)
+    ) {
+        Icon(
+            imageVector = item.icon,
+            contentDescription = stringResource(item.labelRes),
+            tint = MenbresiaColors.TextDisabled,
+            modifier = Modifier.size(22.dp)
+        )
+        Text(
+            text = stringResource(item.labelRes),
+            color = MenbresiaColors.TextDisabled,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Normal
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/SideActions.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/SideActions.kt
@@ -1,0 +1,69 @@
+package com.fahed.perupass.feature.screen.feed.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BookmarkBorder
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SideActions(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(end = 16.dp, bottom = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        ActionItem(
+            icon = Icons.Outlined.FavoriteBorder,
+            label = "2.4K"
+        )
+        ActionItem(
+            icon = Icons.Outlined.Send,
+            label = "SHARE"
+        )
+        ActionItem(
+            icon = Icons.Outlined.BookmarkBorder,
+            label = "SAVE"
+        )
+    }
+}
+
+@Composable
+private fun ActionItem(
+    icon: ImageVector,
+    label: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = label,
+            tint = Color.White,
+            modifier = Modifier.size(28.dp)
+        )
+        Text(
+            text = label,
+            color = Color.White,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 0.3.sp
+        )
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/VenueCard.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/VenueCard.kt
@@ -1,0 +1,66 @@
+package com.fahed.perupass.feature.screen.feed.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.fahed.perupass.R
+import com.fahed.perupass.feature.screen.feed.model.VenueUiModel
+
+@Composable
+fun VenueCard(
+    venue: VenueUiModel,
+    onVenueClicked: (String) -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable { onVenueClicked(venue.id) }
+    ) {
+        AsyncImage(
+            model = venue.imageUrl,
+            contentDescription = stringResource(R.string.feed_venue_image_description, venue.name),
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color.Transparent, Color.Black.copy(alpha = 0.85f)),
+                        startY = 0f,
+                        endY = Float.POSITIVE_INFINITY
+                    )
+                )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                VenueOverlay(
+                    venue = venue,
+                    modifier = Modifier.weight(1f)
+                )
+
+                SideActions(modifier = Modifier.align(Alignment.Bottom))
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/VenueOverlay.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/component/VenueOverlay.kt
@@ -1,0 +1,115 @@
+package com.fahed.perupass.feature.screen.feed.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.fahed.perupass.R
+import com.fahed.perupass.designsystem.MenbresiaColors
+import com.fahed.perupass.feature.screen.feed.model.VenueUiModel
+
+@Composable
+fun VenueOverlay(
+    venue: VenueUiModel,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(start = 20.dp, end = 8.dp, bottom = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        if (venue.isOpen) {
+            OpenNowBadge()
+        }
+
+        // Venue name — ALL CAPS, large, bold
+        Text(
+            text = venue.name.uppercase(),
+            color = Color.White,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 32.sp,
+            letterSpacing = 0.5.sp,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // Distance with location pin icon
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.LocationOn,
+                contentDescription = null,
+                tint = MenbresiaColors.TextSecondary,
+                modifier = Modifier.size(12.dp)
+            )
+            Text(
+                text = venue.distanceFormatted,
+                color = MenbresiaColors.TextSecondary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Normal,
+                letterSpacing = 0.2.sp
+            )
+        }
+
+        // Gold member benefit row
+        if (venue.benefitText.isNotBlank()) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = stringResource(R.string.feed_benefit_icon_description),
+                    tint = MenbresiaColors.Primary,
+                    modifier = Modifier.size(14.dp)
+                )
+                Text(
+                    text = stringResource(R.string.feed_benefit_prefix, venue.benefitText),
+                    color = MenbresiaColors.Primary,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 0.2.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OpenNowBadge() {
+    Text(
+        text = stringResource(R.string.feed_open_now),
+        color = Color.White,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 0.5.sp,
+        modifier = Modifier
+            .background(
+                color = MenbresiaColors.Success,
+                shape = RoundedCornerShape(4.dp)
+            )
+            .padding(horizontal = 10.dp, vertical = 4.dp)
+    )
+}

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/model/VenueUiModel.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/feed/model/VenueUiModel.kt
@@ -1,0 +1,10 @@
+package com.fahed.perupass.feature.screen.feed.model
+
+data class VenueUiModel(
+    val id: String,
+    val name: String,
+    val imageUrl: String,
+    val distanceFormatted: String,
+    val isOpen: Boolean,
+    val benefitText: String
+)

--- a/mobile/app/src/main/java/com/fahed/perupass/feature/screen/placeholder/FeedPlaceholderScreen.kt
+++ b/mobile/app/src/main/java/com/fahed/perupass/feature/screen/placeholder/FeedPlaceholderScreen.kt
@@ -13,22 +13,61 @@ import androidx.compose.ui.unit.sp
 import com.fahed.perupass.R
 import com.fahed.perupass.designsystem.MenbresiaColors
 
-/**
- * Temporary placeholder for the Vibe Feed screen.
- * Will be replaced by SPEC-002 implementation.
- */
 @Composable
-fun FeedPlaceholderScreen() {
+fun ExploreScreen() {
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MenbresiaColors.Background),
+        modifier = Modifier.fillMaxSize().background(MenbresiaColors.Background),
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = stringResource(R.string.feed_coming_soon),
-            color = MenbresiaColors.Primary,
+            text = stringResource(R.string.placeholder_coming_soon),
+            color = MenbresiaColors.TextSecondary,
             fontSize = 18.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+fun PassesScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize().background(MenbresiaColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.placeholder_coming_soon),
+            color = MenbresiaColors.TextSecondary,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+fun ProfileScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize().background(MenbresiaColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.placeholder_coming_soon),
+            color = MenbresiaColors.TextSecondary,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+fun VenueDetailPlaceholderScreen(venueId: String) {
+    Box(
+        modifier = Modifier.fillMaxSize().background(MenbresiaColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.placeholder_venue_detail, venueId),
+            color = MenbresiaColors.TextSecondary,
+            fontSize = 16.sp,
             fontWeight = FontWeight.Medium
         )
     }

--- a/mobile/app/src/main/res/values-en/strings.xml
+++ b/mobile/app/src/main/res/values-en/strings.xml
@@ -18,4 +18,24 @@
 
     <!-- Feed Placeholder -->
     <string name="feed_coming_soon">Vibe Feed — Coming soon</string>
+
+    <!-- Vibe Feed Screen -->
+    <string name="feed_tab_feed">FEED</string>
+    <string name="feed_tab_explore">EXPLORE</string>
+    <string name="feed_tab_passes">PASSES</string>
+    <string name="feed_tab_profile">PROFILE</string>
+    <string name="feed_open_now">OPEN NOW</string>
+    <string name="feed_like_count">2.4K</string>
+    <string name="feed_like_description">Like</string>
+    <string name="feed_share_description">Share</string>
+    <string name="feed_save_description">Save</string>
+    <string name="feed_benefit_icon_description">Gold benefit</string>
+    <string name="feed_benefit_prefix">GOLD MEMBER: %1$s</string>
+    <string name="feed_venue_image_description">Image of %1$s</string>
+    <string name="feed_error_loading">Error loading venues. Please try again.</string>
+    <string name="feed_empty">No venues available.</string>
+
+    <!-- Placeholder screens -->
+    <string name="placeholder_coming_soon">Coming soon</string>
+    <string name="placeholder_venue_detail">Venue detail: %1$s</string>
 </resources>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -18,4 +18,24 @@
 
     <!-- Feed Placeholder -->
     <string name="feed_coming_soon">Vibe Feed — Próximamente</string>
+
+    <!-- Vibe Feed Screen -->
+    <string name="feed_tab_feed">FEED</string>
+    <string name="feed_tab_explore">EXPLORE</string>
+    <string name="feed_tab_passes">PASSES</string>
+    <string name="feed_tab_profile">PROFILE</string>
+    <string name="feed_open_now">OPEN NOW</string>
+    <string name="feed_like_count">2.4K</string>
+    <string name="feed_like_description">Me gusta</string>
+    <string name="feed_share_description">Compartir</string>
+    <string name="feed_save_description">Guardar</string>
+    <string name="feed_benefit_icon_description">Beneficio dorado</string>
+    <string name="feed_benefit_prefix">GOLD MEMBER: %1$s</string>
+    <string name="feed_venue_image_description">Imagen de %1$s</string>
+    <string name="feed_error_loading">Error al cargar los locales. Intenta de nuevo.</string>
+    <string name="feed_empty">No hay locales disponibles.</string>
+
+    <!-- Placeholder screens -->
+    <string name="placeholder_coming_soon">Próximamente</string>
+    <string name="placeholder_venue_detail">Detalle del local: %1$s</string>
 </resources>

--- a/mobile/app/src/test/java/com/fahed/perupass/GetVenuesUseCaseTest.kt
+++ b/mobile/app/src/test/java/com/fahed/perupass/GetVenuesUseCaseTest.kt
@@ -1,0 +1,73 @@
+package com.fahed.perupass
+
+import com.fahed.perupass.domain.model.Venue
+import com.fahed.perupass.domain.repository.VenueRepository
+import com.fahed.perupass.domain.usecase.GetVenuesUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetVenuesUseCaseTest {
+
+    private val venueRepository: VenueRepository = mockk()
+    private lateinit var useCase: GetVenuesUseCase
+
+    @Before
+    fun setUp() {
+        useCase = GetVenuesUseCase(venueRepository)
+    }
+
+    @Test
+    fun `invoke returns success result when repository succeeds`() = runTest {
+        val venues = listOf(
+            Venue(
+                id = "v1", name = "CHANGU CLUB", address = "Cusco", latitude = -13.5,
+                longitude = -71.9, imageUrl = "https://example.com/img.jpg", hours = "10PM",
+                days = "Fri-Sat", rating = 4.8, isOpen = true, pin = "1234",
+                benefits = mapOf("gold" to "Skip the Line")
+            )
+        )
+        coEvery { venueRepository.getVenues() } returns Result.success(venues)
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrNull()?.size)
+        assertEquals("CHANGU CLUB", result.getOrNull()?.first()?.name)
+    }
+
+    @Test
+    fun `invoke returns failure result when repository fails`() = runTest {
+        val exception = RuntimeException("Network error")
+        coEvery { venueRepository.getVenues() } returns Result.failure(exception)
+
+        val result = useCase()
+
+        assertTrue(result.isFailure)
+        assertEquals("Network error", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `invoke returns empty list when no venues`() = runTest {
+        coEvery { venueRepository.getVenues() } returns Result.success(emptyList())
+
+        val result = useCase()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Test
+    fun `invoke calls repository exactly once`() = runTest {
+        coEvery { venueRepository.getVenues() } returns Result.success(emptyList())
+
+        useCase()
+
+        coVerify(exactly = 1) { venueRepository.getVenues() }
+    }
+}

--- a/mobile/app/src/test/java/com/fahed/perupass/VenueMapperTest.kt
+++ b/mobile/app/src/test/java/com/fahed/perupass/VenueMapperTest.kt
@@ -1,0 +1,72 @@
+package com.fahed.perupass
+
+import com.fahed.perupass.data.model.dto.VenueDTO
+import com.fahed.perupass.data.model.mapper.toDomain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VenueMapperTest {
+
+    private val sampleDto = VenueDTO(
+        id = "venue123",
+        name = "CHANGU CLUB",
+        address = "Avenida El Sol 123, Cusco",
+        latitude = -13.5226,
+        longitude = -71.9673,
+        imageUrl = "https://images.unsplash.com/photo-1",
+        hours = "10PM — 4AM",
+        days = "Thur–Sun",
+        rating = 4.8,
+        isOpen = true,
+        pin = "1234",
+        benefits = mapOf(
+            "discovery" to "Cover fee + welcome drink",
+            "gold" to "Skip the Line + 1 Free Drink"
+        )
+    )
+
+    @Test
+    fun `toDomain maps all fields correctly`() {
+        val venue = sampleDto.toDomain()
+
+        assertEquals("venue123", venue.id)
+        assertEquals("CHANGU CLUB", venue.name)
+        assertEquals("Avenida El Sol 123, Cusco", venue.address)
+        assertEquals(-13.5226, venue.latitude, 0.0001)
+        assertEquals(-71.9673, venue.longitude, 0.0001)
+        assertEquals("https://images.unsplash.com/photo-1", venue.imageUrl)
+        assertEquals("10PM — 4AM", venue.hours)
+        assertEquals("Thur–Sun", venue.days)
+        assertEquals(4.8, venue.rating, 0.001)
+        assertEquals("1234", venue.pin)
+    }
+
+    @Test
+    fun `toDomain maps isOpen correctly when true`() {
+        val venue = sampleDto.toDomain()
+        assertTrue(venue.isOpen)
+    }
+
+    @Test
+    fun `toDomain maps isOpen correctly when false`() {
+        val venue = sampleDto.copy(isOpen = false).toDomain()
+        assertFalse(venue.isOpen)
+    }
+
+    @Test
+    fun `toDomain maps benefits map correctly`() {
+        val venue = sampleDto.toDomain()
+
+        assertEquals(2, venue.benefits.size)
+        assertEquals("Cover fee + welcome drink", venue.benefits["discovery"])
+        assertEquals("Skip the Line + 1 Free Drink", venue.benefits["gold"])
+    }
+
+    @Test
+    fun `toDomain maps empty benefits to empty map`() {
+        val venue = sampleDto.copy(benefits = emptyMap()).toDomain()
+        assertTrue(venue.benefits.isEmpty())
+    }
+}

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -17,6 +17,10 @@ hilt = "2.53.1"
 hiltNavigationCompose = "1.2.0"
 navigationCompose = "2.8.9"
 lifecycleViewmodelCompose = "2.8.7"
+coil = "2.7.0"
+playServicesLocation = "21.3.0"
+mockk = "1.13.10"
+coroutinesTest = "1.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +39,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth-ktx" }
@@ -47,6 +52,10 @@ googleid = { group = "com.google.android.libraries.identity.googleid", name = "g
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/screens/MenbresiaAI.text
+++ b/screens/MenbresiaAI.text
@@ -1,0 +1,9173 @@
+{
+  "version": "2.8",
+  "children": [
+    {
+      "type": "frame",
+      "id": "epAaj",
+      "x": 1358,
+      "y": 0,
+      "name": "Mobile - Venue Detail",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#111111",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "mIbfG",
+          "x": 0,
+          "y": 0,
+          "name": "venue-video",
+          "metadata": {
+            "type": "unsplash",
+            "username": "dialfoto",
+            "link": "https://unsplash.com/@dialfoto",
+            "author": "foto DIAL"
+          },
+          "width": 402,
+          "height": 340,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1766650552239-c18affabdfcd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwMjh8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Xz7Hb",
+              "x": 16,
+              "y": 52,
+              "name": "closeBtn",
+              "width": 36,
+              "height": 36,
+              "fill": "#00000088",
+              "cornerRadius": 18,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Cd2ZC",
+                  "name": "closeIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "myTuE",
+              "x": 16,
+              "y": 296,
+              "name": "venueTagRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Jo6mu",
+                  "name": "liveTag",
+                  "fill": "#F44336",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "U9s7I",
+                      "name": "liveText",
+                      "fill": "#FFFFFF",
+                      "content": "LIVE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "jA8K5",
+                  "name": "venueTopName",
+                  "fill": "#FFFFFF",
+                  "content": "CHANGU CLUB",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 13,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "GOFNy",
+          "x": 0,
+          "y": 340,
+          "name": "details-scroll",
+          "width": 402,
+          "height": 534,
+          "layout": "vertical",
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "JIVcq",
+              "name": "infoRow",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "OnFgF",
+                  "name": "addrCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "n3MN1",
+                      "name": "addrLabel",
+                      "fill": "#A0A0A0",
+                      "content": "AVENIDA EL SOL 123, CUSCO",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dOtNY",
+                      "name": "hoursLabel",
+                      "fill": "#A0A0A0",
+                      "content": "Open: 10PM — 4AM  •  Thur–Sun",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mrotK",
+                  "name": "ratingBox",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "sYxEP",
+                      "name": "ratingNum",
+                      "fill": "#D4AF37",
+                      "content": "4.8",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ENrDb",
+                      "name": "ratingLabel",
+                      "fill": "#666666",
+                      "content": "RATING",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "aOPBS",
+              "name": "divider",
+              "fill": "#2A2A2A",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "96Pef",
+              "name": "benefitsLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "KnYOj",
+                  "name": "accentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                },
+                {
+                  "type": "text",
+                  "id": "VvLXc",
+                  "name": "benefitsTitle",
+                  "fill": "#FFFFFF",
+                  "content": "MEMBER BENEFITS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ah5JG",
+              "name": "benefit1",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "pNQkz",
+                  "name": "b1Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "zap",
+                  "iconFontFamily": "lucide",
+                  "fill": "#A0A0A0"
+                },
+                {
+                  "type": "frame",
+                  "id": "iJwO1",
+                  "name": "b1Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MNhNn",
+                      "name": "b1Tier",
+                      "fill": "#A0A0A0",
+                      "content": "VIBE MEMBER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "mU8pm",
+                      "name": "b1Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "Extended Happy Hour until midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "dmbUL",
+              "name": "benefit2",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "i6xkm",
+                  "name": "b2Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "frame",
+                  "id": "edEot",
+                  "name": "b2Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gPqpq",
+                      "name": "b2Tier",
+                      "fill": "#D4AF37",
+                      "content": "GOLD SELECT",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "hoNTq",
+                      "name": "b2Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "Skip the Line + 1 Free Drink",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "xGBAy",
+              "name": "benefit3",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "CKgZD",
+                  "name": "b3Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "crown",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "frame",
+                  "id": "Z9UYr",
+                  "name": "b3Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "AGQzX",
+                      "name": "b3Tier",
+                      "fill": "#A0A0A0",
+                      "content": "BLACK FOUNDER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "QVmGJ",
+                      "name": "b3Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "All-Access + Private Concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JBOHk",
+              "name": "ctaSection",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vI7pb",
+                  "name": "geoLabel",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ogDcN",
+                      "name": "geoIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "radar",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "iawwt",
+                      "name": "geoText",
+                      "fill": "#666666",
+                      "content": "GEOFENCE ACTIVE — YOU MUST BE NEARBY TO ACTIVATE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sHsqt",
+                  "name": "btnDisabled",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": "#282828",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#3A3A3A"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "0Fc2S",
+                      "name": "btnDisabledText",
+                      "fill": "#666666",
+                      "content": "Get Closer to Activate (Geofence Active)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "HAmjS",
+                  "name": "stateLabel",
+                  "fill": "#666666",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "↓  WHEN NEARBY — BUTTON ACTIVATES",
+                  "textAlign": "center",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 9,
+                  "fontWeight": "500",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "II5VS",
+                  "name": "btnActive",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 90,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F5D060",
+                        "position": 0
+                      },
+                      {
+                        "color": "#D4AF37",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#A07820",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 4,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#D4AF3766",
+                    "blur": 20
+                  },
+                  "gap": 10,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "y0p0y",
+                      "name": "boltIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "FpULr",
+                      "name": "btnActiveText",
+                      "fill": "#111111",
+                      "content": "ACTIVATE PASS NOW",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 15,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "bi8Au",
+      "x": 0,
+      "y": 0,
+      "name": "Frame",
+      "clip": true,
+      "width": 800,
+      "height": 600,
+      "fill": "#FFFFFF",
+      "layout": "none"
+    },
+    {
+      "type": "frame",
+      "id": "Xmbgb",
+      "x": 880,
+      "y": 0,
+      "name": "Mobile - Vibe Feed",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#111111",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "OFvmQ",
+          "x": 0,
+          "y": 0,
+          "name": "video-bg",
+          "metadata": {
+            "type": "unsplash",
+            "username": "migelon",
+            "link": "https://unsplash.com/@migelon",
+            "author": "Michael Busch"
+          },
+          "width": 402,
+          "height": 874,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1612660719007-c0251b2e6afb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5Nzc5ODJ8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "gcFXx",
+          "x": 0,
+          "y": 0,
+          "name": "status-bar",
+          "width": 402,
+          "height": 62,
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "Ar78M",
+              "name": "statusTime",
+              "fill": "#FFFFFF",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "bAY2y",
+              "name": "statusIcons",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "eS66b",
+                  "name": "signalIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "LnCDA",
+                  "name": "wifiIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "yFpv0",
+                  "name": "batteryIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ePcHP",
+          "x": 350,
+          "y": 320,
+          "name": "right-actions",
+          "layout": "vertical",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "o7NkG",
+              "name": "heartBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "sZutq",
+                  "name": "heartIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "heart",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "QHTKU",
+                  "name": "heartCount",
+                  "fill": "#FFFFFF",
+                  "content": "2.4K",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IYJ6c",
+              "name": "shareBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "aetjw",
+                  "name": "shareIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "send",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "rOSox",
+                  "name": "shareCount",
+                  "fill": "#FFFFFF",
+                  "content": "SHARE",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JtoYW",
+              "name": "bookmarkBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "TGRWs",
+                  "name": "bookmarkIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "bookmark",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "text",
+                  "id": "oJ8pZ",
+                  "name": "bookmarkCount",
+                  "fill": "#FFFFFF",
+                  "content": "SAVE",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jwiSx",
+          "x": 0,
+          "y": 670,
+          "name": "bottom-gradient",
+          "width": 402,
+          "height": 204,
+          "fill": {
+            "type": "gradient",
+            "gradientType": "linear",
+            "enabled": true,
+            "rotation": 0,
+            "size": {
+              "height": 1
+            },
+            "colors": [
+              {
+                "color": "#00000000",
+                "position": 0
+              },
+              {
+                "color": "#000000EE",
+                "position": 1
+              }
+            ]
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "06I0o",
+          "x": 0,
+          "y": 670,
+          "name": "info-card",
+          "width": 402,
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            16,
+            20
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "HTQfL",
+              "name": "venueName",
+              "fill": "#FFFFFF",
+              "content": "CHANGU CLUB",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 26,
+              "fontWeight": "700",
+              "letterSpacing": -1
+            },
+            {
+              "type": "frame",
+              "id": "sOjd9",
+              "name": "distanceRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Hylqp",
+                  "name": "pinIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "map-pin",
+                  "iconFontFamily": "lucide",
+                  "fill": "#4CAF50"
+                },
+                {
+                  "type": "text",
+                  "id": "QFrJW",
+                  "name": "distText",
+                  "fill": "#4CAF50",
+                  "content": "80m away • OPEN NOW",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZuLMd",
+              "name": "goldBadge",
+              "fill": "#D4AF3720",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "bKF2S",
+                  "name": "starIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "text",
+                  "id": "GEQ0y",
+                  "name": "goldText",
+                  "fill": "#D4AF37",
+                  "content": "GOLD MEMBER: Skip the Line + 1 Free Drink",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "q2xDc",
+          "x": 0,
+          "y": 791,
+          "name": "tab-bar",
+          "width": 402,
+          "height": 83,
+          "padding": [
+            12,
+            21,
+            21,
+            21
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "xUcsn",
+              "name": "tab-pill",
+              "width": "fill_container",
+              "height": 62,
+              "fill": "#1C1C1C",
+              "cornerRadius": 36,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#2A2A2A"
+              },
+              "padding": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KD34F",
+                  "name": "tab1",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#D4AF37",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "NFLuF",
+                      "name": "tab1Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "flame",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "kL8YH",
+                      "name": "tab1Label",
+                      "fill": "#111111",
+                      "content": "FEED",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sMugY",
+                  "name": "tab2",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "3PgCj",
+                      "name": "tab2Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "map",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "wCJP9",
+                      "name": "tab2Label",
+                      "fill": "#666666",
+                      "content": "EXPLORE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mTiNb",
+                  "name": "tab3",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ETrof",
+                      "name": "tab3Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "ticket",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QS5TN",
+                      "name": "tab3Label",
+                      "fill": "#666666",
+                      "content": "PASSES",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "viRbV",
+                  "name": "tab4",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "bJiIM",
+                      "name": "tab4Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "GQcO8",
+                      "name": "tab4Label",
+                      "fill": "#666666",
+                      "content": "PROFILE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "yJ4bJ",
+      "x": 1367,
+      "y": -1391,
+      "name": "Mobile - Venue Detail (Light)",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#F5F5F5",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Ku2LJ",
+          "x": 0,
+          "y": 0,
+          "name": "venue-video",
+          "metadata": {
+            "type": "unsplash",
+            "username": "dialfoto",
+            "link": "https://unsplash.com/@dialfoto",
+            "author": "foto DIAL"
+          },
+          "width": 402,
+          "height": 340,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1766650552239-c18affabdfcd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwMjh8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "R1oNJ",
+              "x": 16,
+              "y": 52,
+              "name": "closeBtn",
+              "width": 36,
+              "height": 36,
+              "fill": "#00000088",
+              "cornerRadius": 18,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "9nIwJ",
+                  "name": "closeIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JTizy",
+              "x": 16,
+              "y": 296,
+              "name": "venueTagRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DjGXG",
+                  "name": "liveTag",
+                  "fill": "#F44336",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "24gRr",
+                      "name": "liveText",
+                      "fill": "#FFFFFF",
+                      "content": "LIVE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "mqGsp",
+                  "name": "venueTopName",
+                  "fill": "#FFFFFF",
+                  "content": "CHANGU CLUB",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 13,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RdFB8",
+          "x": 0,
+          "y": 340,
+          "name": "details-scroll",
+          "width": 402,
+          "height": 534,
+          "fill": "#F5F5F5",
+          "layout": "vertical",
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "rqY3q",
+              "name": "infoRow",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ONa8x",
+                  "name": "addrCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "1BOUj",
+                      "name": "addrLabel",
+                      "fill": "#555555",
+                      "content": "AVENIDA EL SOL 123, CUSCO",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "nNE5u",
+                      "name": "hoursLabel",
+                      "fill": "#555555",
+                      "content": "Open: 10PM — 4AM  •  Thur–Sun",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pOKFG",
+                  "name": "ratingBox",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "O0u8z",
+                      "name": "ratingNum",
+                      "fill": "#D4AF37",
+                      "content": "4.8",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "DpCIF",
+                      "name": "ratingLabel",
+                      "fill": "#888888",
+                      "content": "RATING",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "KJqIr",
+              "name": "divider",
+              "fill": "#DEDEDE",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "KBPZi",
+              "name": "benefitsLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "ZUB1T",
+                  "name": "accentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                },
+                {
+                  "type": "text",
+                  "id": "XbA3H",
+                  "name": "benefitsTitle",
+                  "fill": "#1A1A2E",
+                  "content": "MEMBER BENEFITS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RdaY1",
+              "name": "benefit1",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "z5PRV",
+                  "name": "b1Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "zap",
+                  "iconFontFamily": "lucide",
+                  "fill": "#A0A0A0"
+                },
+                {
+                  "type": "frame",
+                  "id": "C8DrK",
+                  "name": "b1Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "usWtV",
+                      "name": "b1Tier",
+                      "fill": "#888888",
+                      "content": "VIBE MEMBER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "j9hon",
+                      "name": "b1Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "Extended Happy Hour until midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "4c8sL",
+              "name": "benefit2",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "t8Uve",
+                  "name": "b2Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "frame",
+                  "id": "dVgRU",
+                  "name": "b2Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rft17",
+                      "name": "b2Tier",
+                      "fill": "#D4AF37",
+                      "content": "GOLD SELECT",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "ZXpHj",
+                      "name": "b2Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "Skip the Line + 1 Free Drink",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "SDphY",
+              "name": "benefit3",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "DR9b9",
+                  "name": "b3Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "crown",
+                  "iconFontFamily": "lucide",
+                  "fill": "#1A1A2E"
+                },
+                {
+                  "type": "frame",
+                  "id": "WkYcJ",
+                  "name": "b3Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "WLlW2",
+                      "name": "b3Tier",
+                      "fill": "#888888",
+                      "content": "BLACK FOUNDER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "wBF6X",
+                      "name": "b3Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "All-Access + Private Concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "1O5h9",
+              "name": "ctaSection",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "RF0Yo",
+                  "name": "geoLabel",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "3J32o",
+                      "name": "geoIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "radar",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "NUkFd",
+                      "name": "geoText",
+                      "fill": "#666666",
+                      "content": "GEOFENCE ACTIVE — YOU MUST BE NEARBY TO ACTIVATE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D0oCC",
+                  "name": "btnDisabled",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": "#E8E8E8",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#D0D0D0"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hfdWW",
+                      "name": "btnDisabledText",
+                      "fill": "#888888",
+                      "content": "Get Closer to Activate (Geofence Active)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "dRKkS",
+                  "name": "stateLabel",
+                  "fill": "#AAAAAA",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "↓  WHEN NEARBY — BUTTON ACTIVATES",
+                  "textAlign": "center",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 9,
+                  "fontWeight": "500",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "n6GhJ",
+                  "name": "btnActive",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 90,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F5D060",
+                        "position": 0
+                      },
+                      {
+                        "color": "#D4AF37",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#A07820",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 4,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#D4AF3766",
+                    "blur": 20
+                  },
+                  "gap": 10,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wMsla",
+                      "name": "boltIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "4LI7M",
+                      "name": "btnActiveText",
+                      "fill": "#111111",
+                      "content": "ACTIVATE PASS NOW",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 15,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "YGmwq",
+          "x": 0,
+          "y": 0,
+          "name": "pin-modal-overlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#00000055",
+          "layout": "vertical",
+          "justifyContent": "end",
+          "alignItems": "center"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "mmElw",
+      "x": 1831,
+      "y": 0,
+      "name": "Mobile - Venue Detail - Merchant PIN",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#111111",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "KSoUw",
+          "x": 0,
+          "y": 0,
+          "name": "venue-video",
+          "metadata": {
+            "type": "unsplash",
+            "username": "dialfoto",
+            "link": "https://unsplash.com/@dialfoto",
+            "author": "foto DIAL"
+          },
+          "width": 402,
+          "height": 340,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1766650552239-c18affabdfcd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwMjh8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "M6nIa",
+              "x": 16,
+              "y": 52,
+              "name": "closeBtn",
+              "width": 36,
+              "height": 36,
+              "fill": "#00000088",
+              "cornerRadius": 18,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "1VkGG",
+                  "name": "closeIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "x2XD5",
+              "x": 16,
+              "y": 296,
+              "name": "venueTagRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "1Q4pb",
+                  "name": "liveTag",
+                  "fill": "#F44336",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RlI5k",
+                      "name": "liveText",
+                      "fill": "#FFFFFF",
+                      "content": "LIVE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "hZmrB",
+                  "name": "venueTopName",
+                  "fill": "#FFFFFF",
+                  "content": "CHANGU CLUB",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 13,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "VljGP",
+          "x": 0,
+          "y": 340,
+          "name": "details-scroll",
+          "width": 402,
+          "height": 534,
+          "layout": "vertical",
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "OwXrt",
+              "name": "infoRow",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "grwGc",
+                  "name": "addrCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "1c0dS",
+                      "name": "addrLabel",
+                      "fill": "#A0A0A0",
+                      "content": "AVENIDA EL SOL 123, CUSCO",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IAVg0",
+                      "name": "hoursLabel",
+                      "fill": "#A0A0A0",
+                      "content": "Open: 10PM — 4AM  •  Thur–Sun",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e26PL",
+                  "name": "ratingBox",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CHkvH",
+                      "name": "ratingNum",
+                      "fill": "#D4AF37",
+                      "content": "4.8",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5ePMA",
+                      "name": "ratingLabel",
+                      "fill": "#666666",
+                      "content": "RATING",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "837h7",
+              "name": "divider",
+              "fill": "#2A2A2A",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "VCoV3",
+              "name": "benefitsLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "THq1x",
+                  "name": "accentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                },
+                {
+                  "type": "text",
+                  "id": "zlXL5",
+                  "name": "benefitsTitle",
+                  "fill": "#FFFFFF",
+                  "content": "MEMBER BENEFITS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l12iK",
+              "name": "benefit1",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "upyWH",
+                  "name": "b1Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "zap",
+                  "iconFontFamily": "lucide",
+                  "fill": "#A0A0A0"
+                },
+                {
+                  "type": "frame",
+                  "id": "EcwIJ",
+                  "name": "b1Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ozkEb",
+                      "name": "b1Tier",
+                      "fill": "#A0A0A0",
+                      "content": "VIBE MEMBER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "X07o9",
+                      "name": "b1Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "Extended Happy Hour until midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "b9fAe",
+              "name": "benefit2",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "J2tBM",
+                  "name": "b2Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "frame",
+                  "id": "025NB",
+                  "name": "b2Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "4cSEa",
+                      "name": "b2Tier",
+                      "fill": "#D4AF37",
+                      "content": "GOLD SELECT",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "no2Tc",
+                      "name": "b2Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "Skip the Line + 1 Free Drink",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0toA4",
+              "name": "benefit3",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "VLOmY",
+                  "name": "b3Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "crown",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "frame",
+                  "id": "RRsfz",
+                  "name": "b3Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yxnRs",
+                      "name": "b3Tier",
+                      "fill": "#A0A0A0",
+                      "content": "BLACK FOUNDER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "KZKaQ",
+                      "name": "b3Benefit",
+                      "fill": "#FFFFFF",
+                      "content": "All-Access + Private Concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Uc4fu",
+              "name": "ctaSection",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fPq76",
+                  "name": "geoLabel",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "jTO9a",
+                      "name": "geoIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "radar",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ne650",
+                      "name": "geoText",
+                      "fill": "#666666",
+                      "content": "GEOFENCE ACTIVE — YOU MUST BE NEARBY TO ACTIVATE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DSGgV",
+                  "name": "btnDisabled",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": "#282828",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#3A3A3A"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "2s6bv",
+                      "name": "btnDisabledText",
+                      "fill": "#666666",
+                      "content": "Get Closer to Activate (Geofence Active)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "mGGyY",
+                  "name": "stateLabel",
+                  "fill": "#666666",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "↓  WHEN NEARBY — BUTTON ACTIVATES",
+                  "textAlign": "center",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 9,
+                  "fontWeight": "500",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "2i3as",
+                  "name": "btnActive",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 90,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F5D060",
+                        "position": 0
+                      },
+                      {
+                        "color": "#D4AF37",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#A07820",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 4,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#D4AF3766",
+                    "blur": 20
+                  },
+                  "gap": 10,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "WiFXg",
+                      "name": "boltIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LogO7",
+                      "name": "btnActiveText",
+                      "fill": "#111111",
+                      "content": "ACTIVATE PASS NOW",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 15,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "zokuw",
+          "x": 0,
+          "y": 0,
+          "name": "pin-modal-overlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#000000CC",
+          "layout": "vertical",
+          "justifyContent": "end",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "cJfxh",
+              "name": "pin-sheet",
+              "width": 402,
+              "fill": "#1C1C1C",
+              "cornerRadius": 20,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#2A2A2A"
+              },
+              "layout": "vertical",
+              "gap": 24,
+              "padding": [
+                28,
+                24,
+                40,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "MCPQa",
+                  "name": "sheetHandle",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 2,
+                      "id": "7QKnW",
+                      "name": "handleBar",
+                      "fill": "#3A3A3A",
+                      "width": 40,
+                      "height": 4
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "i6mbw",
+                  "name": "sheetHeader",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "g0B6Z",
+                      "name": "sheetIconFrame",
+                      "width": 52,
+                      "height": 52,
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 26,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "v52G4",
+                          "name": "sheetIcon",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "shield-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "8cOhj",
+                      "name": "sheetTitle",
+                      "fill": "#FFFFFF",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "ENTER MERCHANT PIN",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700",
+                      "letterSpacing": -0.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "VDgY2",
+                      "name": "sheetSubtitle",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Show this screen to the venue staff",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zW1OY",
+                      "name": "benefitChip",
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#D4AF37"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "VCOGx",
+                          "name": "chipStar",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "star",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        },
+                        {
+                          "type": "text",
+                          "id": "73zEV",
+                          "name": "chipText",
+                          "fill": "#D4AF37",
+                          "content": "Gold: Skip Line + 1 Free Drink",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Xjgqe",
+                  "name": "pinDotsRow",
+                  "width": "fill_container",
+                  "gap": 20,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "P3H5A",
+                      "name": "pd1",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "gNbZz",
+                      "name": "pd2",
+                      "fill": "#3A3A3A",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#666666"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "NwZmD",
+                      "name": "pd3",
+                      "fill": "#3A3A3A",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#666666"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "UWQMr",
+                      "name": "pd4",
+                      "fill": "#3A3A3A",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#666666"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oO9ga",
+                  "name": "mkrow1",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ywFRI",
+                      "name": "mk1",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "l3yll",
+                          "name": "mk1n",
+                          "fill": "#FFFFFF",
+                          "content": "1",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "7PwBD",
+                      "name": "mk2",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ON8E3",
+                          "name": "mk2n",
+                          "fill": "#FFFFFF",
+                          "content": "2",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kvZaR",
+                      "name": "mk3",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "qWQtN",
+                          "name": "mk3n",
+                          "fill": "#FFFFFF",
+                          "content": "3",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dw79V",
+                  "name": "mkrow2",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "AyOQe",
+                      "name": "mk4",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "4fztE",
+                          "name": "mk4n",
+                          "fill": "#FFFFFF",
+                          "content": "4",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QV814",
+                      "name": "mk5",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "z0bBo",
+                          "name": "mk5n",
+                          "fill": "#FFFFFF",
+                          "content": "5",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uoIcT",
+                      "name": "mk6",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VqBZP",
+                          "name": "mk6n",
+                          "fill": "#FFFFFF",
+                          "content": "6",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eCxQF",
+                  "name": "mkrow3",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rkAb8",
+                      "name": "mk7",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "9Xhn9",
+                          "name": "mk7n",
+                          "fill": "#FFFFFF",
+                          "content": "7",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "on5iG",
+                      "name": "mk8",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "93kWj",
+                          "name": "mk8n",
+                          "fill": "#FFFFFF",
+                          "content": "8",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zwQJW",
+                      "name": "mk9",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "EnUTM",
+                          "name": "mk9n",
+                          "fill": "#FFFFFF",
+                          "content": "9",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DtOGB",
+                  "name": "mkrow4",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XKyyZ",
+                      "name": "mkEmpty",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#00000000",
+                      "cornerRadius": 4
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ptk5n",
+                      "name": "mk0",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BN6pb",
+                          "name": "mk0n",
+                          "fill": "#FFFFFF",
+                          "content": "0",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "wwNOh",
+                      "name": "mkDel",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#282828",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "W8Ws9",
+                          "name": "mkDelIcon",
+                          "width": 22,
+                          "height": 22,
+                          "iconFontName": "delete",
+                          "iconFontFamily": "lucide",
+                          "fill": "#A0A0A0"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Ao7hn",
+                  "name": "cancelBtn",
+                  "width": "fill_container",
+                  "height": 44,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "vgmwe",
+                      "name": "cancelText",
+                      "fill": "#666666",
+                      "content": "Cancel",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "OqvhW",
+      "x": 2311,
+      "y": 0,
+      "name": "Mobile - PIN Validation",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#111111",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "6vDLe",
+          "x": 0,
+          "y": 0,
+          "name": "pinBg",
+          "metadata": {
+            "type": "unsplash",
+            "username": "5tep5",
+            "link": "https://unsplash.com/@5tep5",
+            "author": "Aleksandr Popov"
+          },
+          "width": 402,
+          "height": 874,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1564736676781-d0f57b29f67a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwODB8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "GNm68",
+          "x": 0,
+          "y": 0,
+          "name": "pinOverlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#000000CC",
+          "layout": "vertical",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "7pFGL",
+              "name": "pinCard",
+              "width": 362,
+              "fill": "#1C1C1C",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#2A2A2A"
+              },
+              "layout": "vertical",
+              "gap": 28,
+              "padding": [
+                36,
+                28
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zpFZ3",
+                  "name": "pinHeader",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zdAFl",
+                      "name": "lockIcon",
+                      "width": 52,
+                      "height": 52,
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 26,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "80Aq1",
+                          "name": "lockIconInner",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "shield-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "z9vei",
+                      "name": "pinTitle",
+                      "fill": "#FFFFFF",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "ENTER MERCHANT PIN",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700",
+                      "letterSpacing": -0.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "19qZL",
+                      "name": "pinSubtitle",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "To Redeem Your Pass Benefit",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eAVx3",
+                  "name": "pinDots",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "7c5ik",
+                      "name": "dot1",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "2pzO0",
+                      "name": "dot2",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "CvZHn",
+                      "name": "dot3",
+                      "fill": "#3A3A3A",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#666666"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "1klhC",
+                      "name": "dot4",
+                      "fill": "#3A3A3A",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#666666"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jQZqp",
+                  "name": "keypad",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "3HYVu",
+                      "name": "krow1",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "2gWzo",
+                          "name": "k1",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Foy4M",
+                              "name": "k1n",
+                              "fill": "#FFFFFF",
+                              "content": "1",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "pR0a4",
+                          "name": "k2",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NanCQ",
+                              "name": "k2n",
+                              "fill": "#FFFFFF",
+                              "content": "2",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "H0EBc",
+                          "name": "k3",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "V7U30",
+                              "name": "k3n",
+                              "fill": "#FFFFFF",
+                              "content": "3",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MNW9i",
+                      "name": "krow2",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WaHdd",
+                          "name": "k4",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "P0TaT",
+                              "name": "k4n",
+                              "fill": "#FFFFFF",
+                              "content": "4",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ogye3",
+                          "name": "k5",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NOBx6",
+                              "name": "k5n",
+                              "fill": "#FFFFFF",
+                              "content": "5",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "shr8x",
+                          "name": "k6",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "S3pts",
+                              "name": "k6n",
+                              "fill": "#FFFFFF",
+                              "content": "6",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "LUoiv",
+                      "name": "krow3",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "tKNGz",
+                          "name": "k7",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ieO5r",
+                              "name": "k7n",
+                              "fill": "#FFFFFF",
+                              "content": "7",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "rhnkW",
+                          "name": "k8",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nriJI",
+                              "name": "k8n",
+                              "fill": "#FFFFFF",
+                              "content": "8",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "L3t9g",
+                          "name": "k9",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "qW7Ws",
+                              "name": "k9n",
+                              "fill": "#FFFFFF",
+                              "content": "9",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TObBB",
+                      "name": "krow4",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Rtczm",
+                          "name": "kEmpty",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#00000000",
+                          "cornerRadius": 4
+                        },
+                        {
+                          "type": "frame",
+                          "id": "8zKRs",
+                          "name": "k0",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ShuSI",
+                              "name": "k0n",
+                              "fill": "#FFFFFF",
+                              "content": "0",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G4ulY",
+                          "name": "kDel",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#282828",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "9DBoq",
+                              "name": "kDelIcon",
+                              "width": 22,
+                              "height": 22,
+                              "iconFontName": "delete",
+                              "iconFontFamily": "lucide",
+                              "fill": "#A0A0A0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "E3BBb",
+          "x": 0,
+          "y": 0,
+          "name": "successOverlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#000000EE",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            28
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "ZTBYQ",
+              "name": "checkCircle",
+              "width": 100,
+              "height": 100,
+              "fill": "#4CAF5020",
+              "cornerRadius": 50,
+              "stroke": {
+                "align": "inside",
+                "thickness": 2,
+                "fill": "#4CAF50"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "5Kxky",
+                  "name": "checkIcon",
+                  "width": 48,
+                  "height": 48,
+                  "iconFontName": "check",
+                  "iconFontFamily": "lucide",
+                  "fill": "#4CAF50"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "nnKlb",
+              "name": "passActive",
+              "fill": "#FFFFFF",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "PASS ACTIVE!",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 36,
+              "fontWeight": "700",
+              "letterSpacing": -1
+            },
+            {
+              "type": "text",
+              "id": "dbld4",
+              "name": "benefitConfirmed",
+              "fill": "#A0A0A0",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Benefit Confirmed:",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 14
+            },
+            {
+              "type": "text",
+              "id": "hbxVt",
+              "name": "benefitValue",
+              "fill": "#4CAF50",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "2x1 Gin Tonic",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 22,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "Jt2LS",
+              "name": "timerFrame",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "0KSnR",
+                  "name": "timerLabel",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "5QoWI",
+                      "name": "timerText",
+                      "fill": "#666666",
+                      "content": "VALID FOR",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "qKD0e",
+                      "name": "timerCountdown",
+                      "fill": "#4CAF50",
+                      "content": "4:52 remaining",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "U3qV7",
+                  "name": "timerTrack",
+                  "width": "fill_container",
+                  "height": 6,
+                  "fill": "#282828",
+                  "cornerRadius": 3,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "6SW21",
+                      "name": "timerBar",
+                      "width": 270,
+                      "height": 6,
+                      "fill": {
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 90,
+                        "size": {
+                          "height": 1
+                        },
+                        "colors": [
+                          {
+                            "color": "#4CAF50",
+                            "position": 0
+                          },
+                          {
+                            "color": "#2E7D32",
+                            "position": 1
+                          }
+                        ]
+                      },
+                      "cornerRadius": 3
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "oYc72",
+      "x": 2810,
+      "y": 0,
+      "name": "Mobile - Membership",
+      "clip": true,
+      "width": 402,
+      "height": 1100,
+      "fill": "#111111",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "UaLoh",
+          "name": "mem-status",
+          "width": "fill_container",
+          "height": 62,
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "THvQp",
+              "name": "memTime",
+              "fill": "#FFFFFF",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "79R9W",
+              "name": "memStatusIcons",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "j3s1z",
+                  "name": "msig",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "p4Q1w",
+                  "name": "mbat",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "FfqaY",
+          "name": "memHeader",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "padding": [
+            20,
+            20,
+            16,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "vuqGH",
+              "name": "memHeaderLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "Xo5eq",
+                  "name": "memAccentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "wRDan",
+              "name": "memTitle",
+              "fill": "#FFFFFF",
+              "content": "CHOOSE YOUR ACCESS LEVEL",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 22,
+              "fontWeight": "700",
+              "letterSpacing": -0.5
+            },
+            {
+              "type": "text",
+              "id": "g00dx",
+              "name": "memSubtitle",
+              "fill": "#A0A0A0",
+              "content": "Unlock exclusive Cusco nightlife benefits",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 13
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "zZLMU",
+          "name": "cards-area",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            0,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "rFNim",
+              "name": "card1",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#2A2A2A"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "gfuCD",
+                  "name": "c1top",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CMNFV",
+                      "name": "c1label",
+                      "fill": "#A0A0A0",
+                      "content": "ONE-TIME PAY",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "V2KZe",
+                      "name": "c1price",
+                      "fill": "#FFFFFF",
+                      "content": "S/9.90",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "wvjX7",
+                  "name": "c1name",
+                  "fill": "#FFFFFF",
+                  "content": "DISCOVERY PASS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "RGwvX",
+                  "name": "c1benefit",
+                  "fill": "#A0A0A0",
+                  "content": "10 Tokens · Explore every venue type",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "cX1Nx",
+                  "name": "d1b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "u1euc",
+                      "name": "d1b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "llCRA",
+                      "name": "d1b1t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Specialty coffee + selected side",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fSB6H",
+                  "name": "d1b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ixaJP",
+                      "name": "d1b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "LkPy3",
+                      "name": "d1b2t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Dish from curated Discovery Menu",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xznI5",
+                  "name": "d1b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "3ghKf",
+                      "name": "d1b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "V9pPg",
+                      "name": "d1b3t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Signature cocktail or craft beer flight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5uR8l",
+                  "name": "d1b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "02Xwx",
+                      "name": "d1b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "music-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "3fK1M",
+                      "name": "d1b4t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Cover fee + welcome drink included",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Vb0Ao",
+              "name": "card2",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 2,
+                "fill": "#D4AF37"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#D4AF3740",
+                "blur": 16
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "8TKL4",
+                  "name": "c2topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QvpIa",
+                      "name": "c2badge",
+                      "fill": "#D4AF37",
+                      "cornerRadius": 4,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "omTYz",
+                          "name": "c2badgeText",
+                          "fill": "#111111",
+                          "content": "RECOMMENDED",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 9,
+                          "fontWeight": "700",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "bHopR",
+                      "name": "c2price",
+                      "fill": "#D4AF37",
+                      "content": "S/19.90/mo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "PMAsz",
+                  "name": "c2name",
+                  "fill": "#FFFFFF",
+                  "content": "VIBE MEMBER",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "xrBXN",
+                  "name": "c2sub",
+                  "fill": "#A0A0A0",
+                  "content": "MONTHLY SUBSCRIPTION",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "Ck3Ko",
+                  "name": "c2benefit",
+                  "fill": "#A0A0A0",
+                  "content": "15 Exploration Tokens / month",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "pgFUd",
+                  "name": "c2trial",
+                  "fill": "#D4AF3720",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "INyjM",
+                      "name": "c2trialText",
+                      "fill": "#D4AF37",
+                      "content": "1 MONTH FREE TRIAL",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yUjNO",
+                  "name": "d2b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "S9LJc",
+                      "name": "d2b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "mfLiH",
+                      "name": "d2b1t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free upsize or small dessert with combo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SEwwu",
+                  "name": "d2b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Vb3d7",
+                      "name": "d2b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "9pks4",
+                      "name": "d2b2t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free appetizer or drink (Mon–Thu)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "24vIL",
+                  "name": "d2b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "P08no",
+                      "name": "d2b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zD588",
+                      "name": "d2b3t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "2-for-1 cocktails until 9 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BM3J0",
+                  "name": "d2b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "BYyCl",
+                      "name": "d2b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "music-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#A0A0A0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "SHY5s",
+                      "name": "d2b4t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free entry ($0 cover) before midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "roQUS",
+              "name": "card3",
+              "width": "fill_container",
+              "fill": "#1C1C1C",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "XWLaL",
+                  "name": "c3topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pGROc",
+                      "name": "c3sub",
+                      "fill": "#D4AF37",
+                      "content": "MONTHLY SUBSCRIPTION",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "hAg2N",
+                      "name": "c3price",
+                      "fill": "#D4AF37",
+                      "content": "S/49.90/mo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "8NwVs",
+                  "name": "c3name",
+                  "fill": "#D4AF37",
+                  "content": "GOLD SELECT",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "ZYwM9",
+                  "name": "c3benefit",
+                  "fill": "#D4AF37",
+                  "content": "30 high-value Exploration Tokens / month",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "jdtC3",
+                  "name": "d3b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zhWmF",
+                      "name": "d3b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "OihjI",
+                      "name": "d3b1t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Table reservation + free Americano refill",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "2LDcT",
+                  "name": "d3b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "28r7l",
+                      "name": "d3b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w6SvX",
+                      "name": "d3b2t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Waitlist priority + 1 free corkage/month",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4s7fi",
+                  "name": "d3b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "4j6Ot",
+                      "name": "d3b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "0QGXR",
+                      "name": "d3b3t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Flash Tastings + table reserved until 10 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "5az0d",
+                  "name": "d3b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "M0Iya",
+                      "name": "d3b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "TEEAj",
+                      "name": "d3b4t",
+                      "fill": "#A0A0A0",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Fast-Pass entry + exclusive bar access",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "7zZ6L",
+              "name": "card4",
+              "width": "fill_container",
+              "fill": "#111111",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#3A3A3A"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "e6z3a",
+                  "name": "c4topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "juI6D",
+                      "name": "c4sub",
+                      "fill": "#666666",
+                      "content": "INVITE ONLY / ANNUAL",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "KZYuT",
+                      "name": "c4inviteIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "crown",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "oHynL",
+                  "name": "c4name",
+                  "fill": "#FFFFFF",
+                  "content": "BLACK FOUNDER",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "9338B",
+                  "name": "c4benefit",
+                  "fill": "#A0A0A0",
+                  "content": "All-Access Pass · No token limits",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "8R8dy",
+                  "name": "c4badge",
+                  "fill": "#282828",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "S8Pfj",
+                      "name": "c4badgeText",
+                      "fill": "#A0A0A0",
+                      "content": "APPLICATION REQUIRED",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zXnyF",
+                  "name": "d4b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "yzGnl",
+                      "name": "d4b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "zmBYJ",
+                      "name": "d4b1t",
+                      "fill": "#666666",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Limited-edition beans + private event rates",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Pn8H9",
+                  "name": "d4b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "78zhR",
+                      "name": "d4b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "45Npi",
+                      "name": "d4b2t",
+                      "fill": "#666666",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Chef&apos;s Table + exclusive tasting dinners",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ElrZK",
+                  "name": "d4b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "2gyMD",
+                      "name": "d4b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "oh7uD",
+                      "name": "d4b3t",
+                      "fill": "#666666",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Personal liquor locker + premium glassware",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KXOpi",
+                  "name": "d4b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "50ywP",
+                      "name": "d4b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "crown",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFFFFF"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yWdeG",
+                      "name": "d4b4t",
+                      "fill": "#666666",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Skip line +2 guests · DJ access · VIP concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "svvZf",
+      "x": 858,
+      "y": 1286,
+      "name": "Web - Admin Dashboard",
+      "clip": true,
+      "width": 1280,
+      "height": 900,
+      "fill": "#F5F5F5",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Cm0ft",
+          "name": "sidebar",
+          "width": 220,
+          "height": "fill_container",
+          "fill": "#1A1A2E",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "E7Ust",
+              "name": "sidebarLogo",
+              "width": "fill_container",
+              "height": 70,
+              "fill": "#111111",
+              "gap": 10,
+              "padding": [
+                0,
+                24
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "QV6S8",
+                  "name": "logoIcon",
+                  "width": 22,
+                  "height": 22,
+                  "iconFontName": "zap",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "text",
+                  "id": "67VWN",
+                  "name": "logoText",
+                  "fill": "#FFFFFF",
+                  "content": "PASE VIBE",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 16,
+                  "fontWeight": "700",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "HRJA7",
+                  "name": "logoSubText",
+                  "fill": "#D4AF37",
+                  "content": "Admin",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 12
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vnwxl",
+              "name": "sidebarNav",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "padding": [
+                20,
+                12
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "xUyHp",
+                  "name": "navItem1",
+                  "width": "fill_container",
+                  "height": 44,
+                  "fill": "#D4AF3718",
+                  "cornerRadius": 6,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "LZrzA",
+                      "name": "navI1Icon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "layout-dashboard",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JICyg",
+                      "name": "navI1Text",
+                      "fill": "#D4AF37",
+                      "content": "Dashboard",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MAZkn",
+                  "name": "navItem2",
+                  "width": "fill_container",
+                  "height": 44,
+                  "cornerRadius": 6,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wWUiX",
+                      "name": "navI2Icon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "building-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8888AA"
+                    },
+                    {
+                      "type": "text",
+                      "id": "7gQHQ",
+                      "name": "navI2Text",
+                      "fill": "#8888AA",
+                      "content": "My Venues",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "2sARj",
+                  "name": "navItem3",
+                  "width": "fill_container",
+                  "height": 44,
+                  "cornerRadius": 6,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "HRXqZ",
+                      "name": "navI3Icon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "list-checks",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8888AA"
+                    },
+                    {
+                      "type": "text",
+                      "id": "bXOJv",
+                      "name": "navI3Text",
+                      "fill": "#8888AA",
+                      "content": "Validations Log",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "7X02F",
+                  "name": "navItem4",
+                  "width": "fill_container",
+                  "height": 44,
+                  "cornerRadius": 6,
+                  "gap": 12,
+                  "padding": [
+                    0,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "rldON",
+                      "name": "navI4Icon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#8888AA"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VZb3J",
+                      "name": "navI4Text",
+                      "fill": "#8888AA",
+                      "content": "Settings",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "by9HB",
+          "name": "main-content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": 32,
+          "children": [
+            {
+              "type": "frame",
+              "id": "nseY8",
+              "name": "topBar",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "43mJ0",
+                  "name": "pageTitle",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "dasO5",
+                      "name": "pageTitleText",
+                      "fill": "#1A1A2E",
+                      "content": "Dashboard",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "oyOYi",
+                      "name": "pageTitleSub",
+                      "fill": "#888888",
+                      "content": "Changu Club — February 2026",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "yaRMv",
+                  "name": "topBarRight",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wmNWC",
+                      "name": "notifBtn",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#F5F5F5",
+                      "cornerRadius": 18,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "gusIa",
+                          "name": "notifIcon",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "bell",
+                          "iconFontFamily": "lucide",
+                          "fill": "#444444"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "q65Bc",
+                      "name": "avatarBtn",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#D4AF37",
+                      "cornerRadius": 18,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "gxhWW",
+                          "name": "avatarText",
+                          "fill": "#111111",
+                          "content": "CC",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 12,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PBsSm",
+              "name": "kpi-row",
+              "width": "fill_container",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vDqJz",
+                  "name": "kpi1",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E8E8E8"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    24,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "qMhbN",
+                      "name": "kpi1top",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "GFy9N",
+                          "name": "kpi1label",
+                          "fill": "#888888",
+                          "content": "TOTAL VALIDATIONS",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Rgusm",
+                          "name": "kpi1icon",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#4CAF5018",
+                          "cornerRadius": 16,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3D4n7",
+                              "name": "kpi1iconInner",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "circle-check",
+                              "iconFontFamily": "lucide",
+                              "fill": "#4CAF50"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "7pYPy",
+                      "name": "kpi1value",
+                      "fill": "#1A1A2E",
+                      "content": "345",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 36,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qIm3s",
+                      "name": "kpi1trend",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "JOxQX",
+                          "name": "kpi1trendIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "trending-up",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4CAF50"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Zkw22",
+                          "name": "kpi1trendText",
+                          "fill": "#4CAF50",
+                          "content": "+12% vs last month",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "VQ2SY",
+                  "name": "kpi2",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E8E8E8"
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    24,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hL6Xl",
+                      "name": "kpi2top",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VfhA6",
+                          "name": "kpi2label",
+                          "fill": "#888888",
+                          "content": "UNIQUE CUSTOMERS",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "w4jix",
+                          "name": "kpi2icon",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#3B82F618",
+                          "cornerRadius": 16,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "0b0bM",
+                              "name": "kpi2iconInner",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "users",
+                              "iconFontFamily": "lucide",
+                              "fill": "#3B82F6"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ncci8",
+                      "name": "kpi2value",
+                      "fill": "#1A1A2E",
+                      "content": "210",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 36,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UypLU",
+                      "name": "kpi2trend",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "28Y8w",
+                          "name": "kpi2trendIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "trending-up",
+                          "iconFontFamily": "lucide",
+                          "fill": "#4CAF50"
+                        },
+                        {
+                          "type": "text",
+                          "id": "VpwFk",
+                          "name": "kpi2trendText",
+                          "fill": "#4CAF50",
+                          "content": "+8% vs last month",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "DuoxB",
+                  "name": "kpi3",
+                  "width": "fill_container",
+                  "fill": "#FFFFFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#D4AF37"
+                  },
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#D4AF3720",
+                    "offset": {
+                      "x": 0,
+                      "y": 2
+                    },
+                    "blur": 12
+                  },
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    24,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iUKjp",
+                      "name": "kpi3top",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QxjBh",
+                          "name": "kpi3label",
+                          "fill": "#888888",
+                          "content": "CURRENT ACTIVE PIN",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600",
+                          "letterSpacing": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "gbA1I",
+                          "name": "kpi3icon",
+                          "width": 32,
+                          "height": 32,
+                          "fill": "#D4AF3718",
+                          "cornerRadius": 16,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "GWu7S",
+                              "name": "kpi3iconInner",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "key-round",
+                              "iconFontFamily": "lucide",
+                              "fill": "#D4AF37"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GWb8m",
+                      "name": "kpi3valueRow",
+                      "width": "fill_container",
+                      "gap": 16,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PYoVz",
+                          "name": "kpi3value",
+                          "fill": "#1A1A2E",
+                          "content": "8821",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 36,
+                          "fontWeight": "700",
+                          "letterSpacing": 4
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ZWtdT",
+                          "name": "rotatePinBtn",
+                          "fill": "#F5F5F5",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E0E0E0"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "u5WLE",
+                              "name": "rotatePinIcon",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "refresh-cw",
+                              "iconFontFamily": "lucide",
+                              "fill": "#444444"
+                            },
+                            {
+                              "type": "text",
+                              "id": "IVZcO",
+                              "name": "rotatePinText",
+                              "fill": "#444444",
+                              "content": "Rotate PIN",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kiERd",
+                      "name": "kpi3trend",
+                      "gap": 4,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "K4zM0",
+                          "name": "kpi3trendIcon",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "timer",
+                          "iconFontFamily": "lucide",
+                          "fill": "#888888"
+                        },
+                        {
+                          "type": "text",
+                          "id": "actTe",
+                          "name": "kpi3trendText",
+                          "fill": "#888888",
+                          "content": "Rotates every 24h automatically",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 12
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "6sL8I",
+              "name": "table-section",
+              "clip": true,
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "1iV7h",
+                  "name": "tableHeader",
+                  "width": "fill_container",
+                  "height": 56,
+                  "fill": "#FFFFFF",
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E8E8E8"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UV1iz",
+                      "name": "tableTitle",
+                      "fill": "#1A1A2E",
+                      "content": "Recent Validations",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "1PS5f",
+                      "name": "tableExport",
+                      "fill": "#F5F5F5",
+                      "cornerRadius": 6,
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "7c61i",
+                          "name": "exportIcon",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "download",
+                          "iconFontFamily": "lucide",
+                          "fill": "#444444"
+                        },
+                        {
+                          "type": "text",
+                          "id": "HMsJ5",
+                          "name": "exportText",
+                          "fill": "#444444",
+                          "content": "Export CSV",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "PIwTL",
+                  "name": "colHeader",
+                  "width": "fill_container",
+                  "height": 40,
+                  "fill": "#F9F9F9",
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#E8E8E8"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "aIENk",
+                      "name": "col1h",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "TIMESTAMP",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.8
+                    },
+                    {
+                      "type": "text",
+                      "id": "W034z",
+                      "name": "col2h",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": 160,
+                      "content": "USER LEVEL",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.8
+                    },
+                    {
+                      "type": "text",
+                      "id": "GA9u4",
+                      "name": "col3h",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "BENEFIT REDEEMED",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.8
+                    },
+                    {
+                      "type": "text",
+                      "id": "2fAdY",
+                      "name": "col4h",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": 100,
+                      "content": "STATUS",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.8
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "38LJz",
+                  "name": "row1",
+                  "width": "fill_container",
+                  "height": 52,
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F0F0F0"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "lQRyf",
+                      "name": "r1c1",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "Today, 11:48 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GNrSk",
+                      "name": "r1c2",
+                      "width": 160,
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ukIgH",
+                          "name": "r1c2badge",
+                          "fill": "#D4AF3720",
+                          "cornerRadius": 4,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SicAi",
+                              "name": "r1c2badgeText",
+                              "fill": "#D4AF37",
+                              "content": "Gold Member",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "JKHyB",
+                      "name": "r1c3",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "Skip the Line + 1 Free Drink",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oyNtY",
+                      "name": "r1c4",
+                      "fill": "#4CAF5018",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "f6uJd",
+                          "name": "r1c4dot",
+                          "fill": "#4CAF50",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "3l4id",
+                          "name": "r1c4text",
+                          "fill": "#4CAF50",
+                          "content": "Success",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "9H4JF",
+                  "name": "row2",
+                  "width": "fill_container",
+                  "height": 52,
+                  "fill": "#FAFAFA",
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F0F0F0"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "24Thb",
+                      "name": "r2c1",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "Today, 11:31 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "GnI8P",
+                      "name": "r2c2",
+                      "width": 160,
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IRnKC",
+                          "name": "r2c2badge",
+                          "fill": "#3B82F618",
+                          "cornerRadius": 4,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "H7T5E",
+                              "name": "r2c2badgeText",
+                              "fill": "#3B82F6",
+                              "content": "Vibe Member",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "k9jgG",
+                      "name": "r2c3",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "Extended Happy Hour",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lB6fU",
+                      "name": "r2c4",
+                      "fill": "#4CAF5018",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "3nDKE",
+                          "name": "r2c4dot",
+                          "fill": "#4CAF50",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ej0fc",
+                          "name": "r2c4text",
+                          "fill": "#4CAF50",
+                          "content": "Success",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UpTWK",
+                  "name": "row3",
+                  "width": "fill_container",
+                  "height": 52,
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F0F0F0"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "kj0pm",
+                      "name": "r3c1",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "Today, 10:55 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "DEfwv",
+                      "name": "r3c2",
+                      "width": 160,
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FI45q",
+                          "name": "r3c2badge",
+                          "fill": "#FFFFFF18",
+                          "cornerRadius": 4,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#666666"
+                          },
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "1WJcL",
+                              "name": "r3c2badgeText",
+                              "fill": "#444444",
+                              "content": "Black Founder",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "HT2m7",
+                      "name": "r3c3",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "All-Access + Concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lypSg",
+                      "name": "r3c4",
+                      "fill": "#4CAF5018",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "rikwZ",
+                          "name": "r3c4dot",
+                          "fill": "#4CAF50",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "MI45u",
+                          "name": "r3c4text",
+                          "fill": "#4CAF50",
+                          "content": "Success",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HHzco",
+                  "name": "row4",
+                  "width": "fill_container",
+                  "height": 52,
+                  "fill": "#FAFAFA",
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F0F0F0"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ScgA1",
+                      "name": "r4c1",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "Today, 10:12 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kOvhe",
+                      "name": "r4c2",
+                      "width": 160,
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "IuYPi",
+                          "name": "r4c2badge",
+                          "fill": "#3B82F618",
+                          "cornerRadius": 4,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "9T8km",
+                              "name": "r4c2badgeText",
+                              "fill": "#3B82F6",
+                              "content": "Vibe Member",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "0Q4ps",
+                      "name": "r4c3",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "2x1 Gin Tonic",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "odCIb",
+                      "name": "r4c4",
+                      "fill": "#4CAF5018",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "4tgRH",
+                          "name": "r4c4dot",
+                          "fill": "#4CAF50",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "h41S4",
+                          "name": "r4c4text",
+                          "fill": "#4CAF50",
+                          "content": "Success",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JLQFh",
+                  "name": "row5",
+                  "width": "fill_container",
+                  "height": 52,
+                  "stroke": {
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#F0F0F0"
+                  },
+                  "padding": [
+                    0,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "XyiOB",
+                      "name": "r5c1",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 180,
+                      "content": "Today, 9:44 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BHwAu",
+                      "name": "r5c2",
+                      "width": 160,
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "oOnIn",
+                          "name": "r5c2badge",
+                          "fill": "#D4AF3720",
+                          "cornerRadius": 4,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "hsQmb",
+                              "name": "r5c2badgeText",
+                              "fill": "#D4AF37",
+                              "content": "Gold Member",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "4h24S",
+                      "name": "r5c3",
+                      "fill": "#444444",
+                      "textGrowth": "fixed-width",
+                      "width": 240,
+                      "content": "Fast-Pass Entry",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MmjyT",
+                      "name": "r5c4",
+                      "fill": "#4CAF5018",
+                      "cornerRadius": 4,
+                      "gap": 5,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "7ZUPI",
+                          "name": "r5c4dot",
+                          "fill": "#4CAF50",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "01COM",
+                          "name": "r5c4text",
+                          "fill": "#4CAF50",
+                          "content": "Success",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "EzlFi",
+      "x": 887,
+      "y": -1391,
+      "name": "Mobile - Vibe Feed (Light)",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#F5F5F5",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "s7yRo",
+          "x": 0,
+          "y": 0,
+          "name": "video-bg",
+          "metadata": {
+            "type": "unsplash",
+            "username": "migelon",
+            "link": "https://unsplash.com/@migelon",
+            "author": "Michael Busch"
+          },
+          "width": 402,
+          "height": 874,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1612660719007-c0251b2e6afb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5Nzc5ODJ8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "i0RWH",
+          "x": 0,
+          "y": 0,
+          "name": "status-bar",
+          "width": 402,
+          "height": 62,
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "2gruE",
+              "name": "statusTime",
+              "fill": "#1A1A2E",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "3vSlh",
+              "name": "statusIcons",
+              "fill": "#1A1A2E",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Bj6l7",
+                  "name": "signalIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "asmel",
+                  "name": "wifiIcon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "wifi",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "2KNOl",
+                  "name": "batteryIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "SmSIo",
+          "x": 350,
+          "y": 320,
+          "name": "right-actions",
+          "layout": "vertical",
+          "gap": 24,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "4wsNL",
+              "name": "heartBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "PCHb5",
+                  "name": "heartIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "heart",
+                  "iconFontFamily": "lucide",
+                  "fill": "#1A1A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "Q31Po",
+                  "name": "heartCount",
+                  "fill": "#1A1A2E",
+                  "content": "2.4K",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Q5gSZ",
+              "name": "shareBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "FYsOi",
+                  "name": "shareIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "send",
+                  "iconFontFamily": "lucide",
+                  "fill": "#1A1A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "dIMCk",
+                  "name": "shareCount",
+                  "fill": "#1A1A2E",
+                  "content": "SHARE",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OaCfL",
+              "name": "bookmarkBtn",
+              "layout": "vertical",
+              "gap": 4,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "iwEey",
+                  "name": "bookmarkIcon",
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "bookmark",
+                  "iconFontFamily": "lucide",
+                  "fill": "#1A1A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "CIGO4",
+                  "name": "bookmarkCount",
+                  "fill": "#1A1A2E",
+                  "content": "SAVE",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "pdT6F",
+          "x": 0,
+          "y": 670,
+          "name": "bottom-gradient",
+          "width": 402,
+          "height": 204,
+          "fill": {
+            "type": "gradient",
+            "gradientType": "linear",
+            "enabled": true,
+            "rotation": 0,
+            "size": {
+              "height": 1
+            },
+            "colors": [
+              {
+                "color": "#FFFFFF00",
+                "position": 0
+              },
+              {
+                "color": "#FFFFFFEE",
+                "position": 1
+              }
+            ]
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "AzbhB",
+          "x": 0,
+          "y": 670,
+          "name": "info-card",
+          "width": 402,
+          "fill": "#ffffffcc",
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            16,
+            20
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "uRSB1",
+              "name": "venueName",
+              "fill": "#1A1A2E",
+              "content": "CHANGU CLUB",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 26,
+              "fontWeight": "700",
+              "letterSpacing": -1
+            },
+            {
+              "type": "frame",
+              "id": "npi8r",
+              "name": "distanceRow",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "irY3O",
+                  "name": "pinIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "map-pin",
+                  "iconFontFamily": "lucide",
+                  "fill": "#4CAF50"
+                },
+                {
+                  "type": "text",
+                  "id": "btzbR",
+                  "name": "distText",
+                  "fill": "#4CAF50",
+                  "content": "80m away • OPEN NOW",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sLgds",
+              "name": "goldBadge",
+              "fill": "#D4AF3720",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "TPp5q",
+                  "name": "starIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "text",
+                  "id": "RAQzW",
+                  "name": "goldText",
+                  "fill": "#D4AF37",
+                  "content": "GOLD MEMBER: Skip the Line + 1 Free Drink",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "nOqEM",
+          "x": 0,
+          "y": 791,
+          "name": "tab-bar",
+          "width": 402,
+          "height": 83,
+          "fill": "#FFFFFF",
+          "padding": [
+            12,
+            21,
+            21,
+            21
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "UuTFy",
+              "name": "tab-pill",
+              "width": "fill_container",
+              "height": 62,
+              "fill": "#F0F0F0",
+              "cornerRadius": 36,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E0E0E0"
+              },
+              "padding": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fp3qT",
+                  "name": "tab1",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#D4AF37",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ir8LK",
+                      "name": "tab1Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "flame",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "L3GDD",
+                      "name": "tab1Label",
+                      "fill": "#111111",
+                      "content": "FEED",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JaBjo",
+                  "name": "tab2",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Yd1xM",
+                      "name": "tab2Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "map",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "vc406",
+                      "name": "tab2Label",
+                      "fill": "#888888",
+                      "content": "EXPLORE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "53R3C",
+                  "name": "tab3",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wrcZX",
+                      "name": "tab3Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "ticket",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "C35p1",
+                      "name": "tab3Label",
+                      "fill": "#888888",
+                      "content": "PASSES",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MLNZN",
+                  "name": "tab4",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "cornerRadius": 26,
+                  "layout": "vertical",
+                  "gap": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "XI4tY",
+                      "name": "tab4Icon",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "user",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ofdIG",
+                      "name": "tab4Label",
+                      "fill": "#888888",
+                      "content": "PROFILE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "otjgW",
+      "x": 1838,
+      "y": -1391,
+      "name": "Mobile - Venue Detail (Light)",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#F5F5F5",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "pKRmn",
+          "x": 0,
+          "y": 0,
+          "name": "venue-video",
+          "metadata": {
+            "type": "unsplash",
+            "username": "dialfoto",
+            "link": "https://unsplash.com/@dialfoto",
+            "author": "foto DIAL"
+          },
+          "width": 402,
+          "height": 340,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1766650552239-c18affabdfcd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwMjh8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none",
+          "children": [
+            {
+              "type": "frame",
+              "id": "74DcV",
+              "x": 16,
+              "y": 52,
+              "name": "closeBtn",
+              "width": 36,
+              "height": 36,
+              "fill": "#00000088",
+              "cornerRadius": 18,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "iBB7X",
+                  "name": "closeIcon",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "x",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ian7L",
+              "x": 16,
+              "y": 296,
+              "name": "venueTagRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qan3V",
+                  "name": "liveTag",
+                  "fill": "#F44336",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "tT8Le",
+                      "name": "liveText",
+                      "fill": "#FFFFFF",
+                      "content": "LIVE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "mIQfE",
+                  "name": "venueTopName",
+                  "fill": "#FFFFFF",
+                  "content": "CHANGU CLUB",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 13,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "wJsMg",
+          "x": 0,
+          "y": 340,
+          "name": "details-scroll",
+          "width": 402,
+          "height": 534,
+          "fill": "#F5F5F5",
+          "layout": "vertical",
+          "padding": 20,
+          "children": [
+            {
+              "type": "frame",
+              "id": "MJPyU",
+              "name": "infoRow",
+              "width": "fill_container",
+              "gap": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vJTio",
+                  "name": "addrCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MtR6E",
+                      "name": "addrLabel",
+                      "fill": "#555555",
+                      "content": "AVENIDA EL SOL 123, CUSCO",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "1hw5R",
+                      "name": "hoursLabel",
+                      "fill": "#555555",
+                      "content": "Open: 10PM — 4AM  •  Thur–Sun",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "GL9tL",
+                  "name": "ratingBox",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "1O6mt",
+                      "name": "ratingNum",
+                      "fill": "#D4AF37",
+                      "content": "4.8",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w907S",
+                      "name": "ratingLabel",
+                      "fill": "#888888",
+                      "content": "RATING",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "Ob9st",
+              "name": "divider",
+              "fill": "#DEDEDE",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "upLQS",
+              "name": "benefitsLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "lKn7x",
+                  "name": "accentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                },
+                {
+                  "type": "text",
+                  "id": "94Geh",
+                  "name": "benefitsTitle",
+                  "fill": "#1A1A2E",
+                  "content": "MEMBER BENEFITS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1.5
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "0efkn",
+              "name": "benefit1",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "yH0PV",
+                  "name": "b1Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "zap",
+                  "iconFontFamily": "lucide",
+                  "fill": "#A0A0A0"
+                },
+                {
+                  "type": "frame",
+                  "id": "JgPy1",
+                  "name": "b1Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "PHqRY",
+                      "name": "b1Tier",
+                      "fill": "#888888",
+                      "content": "VIBE MEMBER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "o0VT6",
+                      "name": "b1Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "Extended Happy Hour until midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "D2xLz",
+              "name": "benefit2",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dnxIc",
+                  "name": "b2Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "star",
+                  "iconFontFamily": "lucide",
+                  "fill": "#D4AF37"
+                },
+                {
+                  "type": "frame",
+                  "id": "4d3WC",
+                  "name": "b2Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "olxgY",
+                      "name": "b2Tier",
+                      "fill": "#D4AF37",
+                      "content": "GOLD SELECT",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "kXA6F",
+                      "name": "b2Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "Skip the Line + 1 Free Drink",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "E0yxK",
+              "name": "benefit3",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "gap": 12,
+              "padding": [
+                12,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "YqoHg",
+                  "name": "b3Icon",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "crown",
+                  "iconFontFamily": "lucide",
+                  "fill": "#1A1A2E"
+                },
+                {
+                  "type": "frame",
+                  "id": "hgaiB",
+                  "name": "b3Col",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "TW21o",
+                      "name": "b3Tier",
+                      "fill": "#888888",
+                      "content": "BLACK FOUNDER",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "P0WLo",
+                      "name": "b3Benefit",
+                      "fill": "#1A1A2E",
+                      "content": "All-Access + Private Concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yFsk2",
+              "name": "ctaSection",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zwMhY",
+                  "name": "geoLabel",
+                  "width": "fill_container",
+                  "gap": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "9vW0C",
+                      "name": "geoIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "radar",
+                      "iconFontFamily": "lucide",
+                      "fill": "#666666"
+                    },
+                    {
+                      "type": "text",
+                      "id": "sYBmE",
+                      "name": "geoText",
+                      "fill": "#666666",
+                      "content": "GEOFENCE ACTIVE — YOU MUST BE NEARBY TO ACTIVATE",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 9,
+                      "fontWeight": "500",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4pDcy",
+                  "name": "btnDisabled",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": "#E8E8E8",
+                  "cornerRadius": 4,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#D0D0D0"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CwY9l",
+                      "name": "btnDisabledText",
+                      "fill": "#888888",
+                      "content": "Get Closer to Activate (Geofence Active)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "1QxnR",
+                  "name": "stateLabel",
+                  "fill": "#AAAAAA",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "↓  WHEN NEARBY — BUTTON ACTIVATES",
+                  "textAlign": "center",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 9,
+                  "fontWeight": "500",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "2UYWn",
+                  "name": "btnActive",
+                  "width": "fill_container",
+                  "height": 54,
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "linear",
+                    "enabled": true,
+                    "rotation": 90,
+                    "size": {
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#F5D060",
+                        "position": 0
+                      },
+                      {
+                        "color": "#D4AF37",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#A07820",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "cornerRadius": 4,
+                  "effect": {
+                    "type": "shadow",
+                    "shadowType": "outer",
+                    "color": "#D4AF3766",
+                    "blur": 20
+                  },
+                  "gap": 10,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hG8Li",
+                      "name": "boltIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#111111"
+                    },
+                    {
+                      "type": "text",
+                      "id": "gVbQA",
+                      "name": "btnActiveText",
+                      "fill": "#111111",
+                      "content": "ACTIVATE PASS NOW",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 15,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "k71Sr",
+          "x": 0,
+          "y": 0,
+          "name": "pin-modal-overlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#00000055",
+          "layout": "vertical",
+          "justifyContent": "end",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Eu8to",
+              "name": "pin-sheet",
+              "width": 402,
+              "fill": "#FFFFFF",
+              "cornerRadius": 20,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E0E0E0"
+              },
+              "layout": "vertical",
+              "gap": 24,
+              "padding": [
+                28,
+                24,
+                40,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "5BLp0",
+                  "name": "sheetHandle",
+                  "width": "fill_container",
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 2,
+                      "id": "wFT9s",
+                      "name": "handleBar",
+                      "fill": "#CCCCCC",
+                      "width": 40,
+                      "height": 4
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "eBWzp",
+                  "name": "sheetHeader",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dOYZl",
+                      "name": "sheetIconFrame",
+                      "width": 52,
+                      "height": 52,
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 26,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "HS1dZ",
+                          "name": "sheetIcon",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "shield-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "v6ESC",
+                      "name": "sheetTitle",
+                      "fill": "#1A1A2E",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "ENTER MERCHANT PIN",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700",
+                      "letterSpacing": -0.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "QodOM",
+                      "name": "sheetSubtitle",
+                      "fill": "#777777",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Show this screen to the venue staff",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    },
+                    {
+                      "type": "frame",
+                      "id": "k1irh",
+                      "name": "benefitChip",
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 4,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#D4AF37"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "nL5Uo",
+                          "name": "chipStar",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "star",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eiPsv",
+                          "name": "chipText",
+                          "fill": "#D4AF37",
+                          "content": "Gold: Skip Line + 1 Free Drink",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZjYDo",
+                  "name": "pinDotsRow",
+                  "width": "fill_container",
+                  "gap": 20,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "bBCAx",
+                      "name": "pd1",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "JC2AW",
+                      "name": "pd2",
+                      "fill": "#E0E0E0",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#CCCCCC"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "w4Lyl",
+                      "name": "pd3",
+                      "fill": "#E0E0E0",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#CCCCCC"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "Sb8TT",
+                      "name": "pd4",
+                      "fill": "#E0E0E0",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#CCCCCC"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KPh89",
+                  "name": "mkrow1",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "06oTU",
+                      "name": "mk1",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TsF8S",
+                          "name": "mk1n",
+                          "fill": "#1A1A2E",
+                          "content": "1",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "89iRj",
+                      "name": "mk2",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7k5gF",
+                          "name": "mk2n",
+                          "fill": "#1A1A2E",
+                          "content": "2",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WA8Js",
+                      "name": "mk3",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "5Huev",
+                          "name": "mk3n",
+                          "fill": "#1A1A2E",
+                          "content": "3",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jqGUz",
+                  "name": "mkrow2",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zhDLE",
+                      "name": "mk4",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "yY0cy",
+                          "name": "mk4n",
+                          "fill": "#1A1A2E",
+                          "content": "4",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ueu8n",
+                      "name": "mk5",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZqcaG",
+                          "name": "mk5n",
+                          "fill": "#1A1A2E",
+                          "content": "5",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2cYwa",
+                      "name": "mk6",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rRTgg",
+                          "name": "mk6n",
+                          "fill": "#1A1A2E",
+                          "content": "6",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JSjPv",
+                  "name": "mkrow3",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "RKTlX",
+                      "name": "mk7",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "kcmkM",
+                          "name": "mk7n",
+                          "fill": "#1A1A2E",
+                          "content": "7",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QZqfX",
+                      "name": "mk8",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "9vAFc",
+                          "name": "mk8n",
+                          "fill": "#1A1A2E",
+                          "content": "8",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UrehW",
+                      "name": "mk9",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lQPac",
+                          "name": "mk9n",
+                          "fill": "#1A1A2E",
+                          "content": "9",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BYgJV",
+                  "name": "mkrow4",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y8P04",
+                      "name": "mkEmpty",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#00000000",
+                      "cornerRadius": 4
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rbobT",
+                      "name": "mk0",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XagNP",
+                          "name": "mk0n",
+                          "fill": "#1A1A2E",
+                          "content": "0",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 24,
+                          "fontWeight": "700"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yMjHH",
+                      "name": "mkDel",
+                      "width": 90,
+                      "height": 62,
+                      "fill": "#F0F0F0",
+                      "cornerRadius": 4,
+                      "layout": "vertical",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "imIHU",
+                          "name": "mkDelIcon",
+                          "width": 22,
+                          "height": 22,
+                          "iconFontName": "delete",
+                          "iconFontFamily": "lucide",
+                          "fill": "#888888"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ghFy6",
+                  "name": "cancelBtn",
+                  "width": "fill_container",
+                  "height": 44,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "f0AAQ",
+                      "name": "cancelText",
+                      "fill": "#AAAAAA",
+                      "content": "Cancel",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ySFll",
+      "x": 2300,
+      "y": -1391,
+      "name": "Mobile - PIN Validation (Light)",
+      "clip": true,
+      "width": 402,
+      "height": 874,
+      "fill": "#F0F2F5",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "PbZMx",
+          "x": 0,
+          "y": 0,
+          "name": "pinBg",
+          "metadata": {
+            "type": "unsplash",
+            "username": "5tep5",
+            "link": "https://unsplash.com/@5tep5",
+            "author": "Aleksandr Popov"
+          },
+          "width": 402,
+          "height": 874,
+          "fill": {
+            "type": "image",
+            "enabled": true,
+            "url": "https://images.unsplash.com/photo-1564736676781-d0f57b29f67a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w4NDM0ODN8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE5NzgwODB8&ixlib=rb-4.1.0&q=80&w=1080",
+            "mode": "fill"
+          },
+          "layout": "none"
+        },
+        {
+          "type": "frame",
+          "id": "evDSK",
+          "x": 0,
+          "y": 0,
+          "name": "pinOverlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#00000033",
+          "layout": "vertical",
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "SlIS2",
+              "name": "pinCard",
+              "width": 362,
+              "fill": "#FFFFFF",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E0E0E0"
+              },
+              "layout": "vertical",
+              "gap": 28,
+              "padding": [
+                36,
+                28
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AEHVc",
+                  "name": "pinHeader",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "q7fGy",
+                      "name": "lockIcon",
+                      "width": 52,
+                      "height": 52,
+                      "fill": "#D4AF3720",
+                      "cornerRadius": 26,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "knpeK",
+                          "name": "lockIconInner",
+                          "width": 24,
+                          "height": 24,
+                          "iconFontName": "shield-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#D4AF37"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "npQtZ",
+                      "name": "pinTitle",
+                      "fill": "#1A1A2E",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "ENTER MERCHANT PIN",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 18,
+                      "fontWeight": "700",
+                      "letterSpacing": -0.5
+                    },
+                    {
+                      "type": "text",
+                      "id": "Igvc0",
+                      "name": "pinSubtitle",
+                      "fill": "#777777",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "To Redeem Your Pass Benefit",
+                      "textAlign": "center",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 13
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "l0tqB",
+                  "name": "pinDots",
+                  "width": "fill_container",
+                  "gap": 16,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "U00ib",
+                      "name": "dot1",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "PywOC",
+                      "name": "dot2",
+                      "fill": "#D4AF37",
+                      "width": 18,
+                      "height": 18
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "fCLxD",
+                      "name": "dot3",
+                      "fill": "#E0E0E0",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#CCCCCC"
+                      }
+                    },
+                    {
+                      "type": "ellipse",
+                      "id": "vVqcu",
+                      "name": "dot4",
+                      "fill": "#E0E0E0",
+                      "width": 18,
+                      "height": 18,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#CCCCCC"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SuIjs",
+                  "name": "keypad",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TegxF",
+                      "name": "krow1",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "HqDRp",
+                          "name": "k1",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "4MotL",
+                              "name": "k1n",
+                              "fill": "#FFFFFF",
+                              "content": "1",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "sNbJ2",
+                          "name": "k2",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "r6fvG",
+                              "name": "k2n",
+                              "fill": "#FFFFFF",
+                              "content": "2",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NO3Np",
+                          "name": "k3",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b5hea",
+                              "name": "k3n",
+                              "fill": "#FFFFFF",
+                              "content": "3",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2NlIJ",
+                      "name": "krow2",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "UOPqo",
+                          "name": "k4",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "LuhJO",
+                              "name": "k4n",
+                              "fill": "#FFFFFF",
+                              "content": "4",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qZoRG",
+                          "name": "k5",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "SX8O8",
+                              "name": "k5n",
+                              "fill": "#FFFFFF",
+                              "content": "5",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "pZQNc",
+                          "name": "k6",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "gap": 2,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "D41Uv",
+                              "name": "k6n",
+                              "fill": "#FFFFFF",
+                              "content": "6",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rVeMl",
+                      "name": "krow3",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "8Wf41",
+                          "name": "k7",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "2jnsm",
+                              "name": "k7n",
+                              "fill": "#FFFFFF",
+                              "content": "7",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hZXUk",
+                          "name": "k8",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "zCV4c",
+                              "name": "k8n",
+                              "fill": "#FFFFFF",
+                              "content": "8",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "8qdSn",
+                          "name": "k9",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "BYBAv",
+                              "name": "k9n",
+                              "fill": "#FFFFFF",
+                              "content": "9",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "u4AQ6",
+                      "name": "krow4",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BVV9C",
+                          "name": "kEmpty",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#00000000",
+                          "cornerRadius": 4
+                        },
+                        {
+                          "type": "frame",
+                          "id": "5stBz",
+                          "name": "k0",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "QJIlP",
+                              "name": "k0n",
+                              "fill": "#FFFFFF",
+                              "content": "0",
+                              "fontFamily": "Space Grotesk",
+                              "fontSize": 22,
+                              "fontWeight": "700"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "4Tj3E",
+                          "name": "kDel",
+                          "width": 80,
+                          "height": 60,
+                          "fill": "#F0F0F0",
+                          "cornerRadius": 4,
+                          "layout": "vertical",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "7yMzp",
+                              "name": "kDelIcon",
+                              "width": 22,
+                              "height": 22,
+                              "iconFontName": "delete",
+                              "iconFontFamily": "lucide",
+                              "fill": "#A0A0A0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "TxftN",
+          "x": 0,
+          "y": 0,
+          "name": "successOverlay",
+          "width": 402,
+          "height": 874,
+          "fill": "#FFFFFFEE",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": [
+            0,
+            28
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "h43m8",
+              "name": "checkCircle",
+              "width": 100,
+              "height": 100,
+              "fill": "#4CAF5015",
+              "cornerRadius": 50,
+              "stroke": {
+                "align": "inside",
+                "thickness": 2,
+                "fill": "#4CAF50"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "9i7fu",
+                  "name": "checkIcon",
+                  "width": 48,
+                  "height": 48,
+                  "iconFontName": "check",
+                  "iconFontFamily": "lucide",
+                  "fill": "#4CAF50"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "lOaTw",
+              "name": "passActive",
+              "fill": "#1A1A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "PASS ACTIVE!",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 36,
+              "fontWeight": "700",
+              "letterSpacing": -1
+            },
+            {
+              "type": "text",
+              "id": "NM7Hb",
+              "name": "benefitConfirmed",
+              "fill": "#777777",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Benefit Confirmed:",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 14
+            },
+            {
+              "type": "text",
+              "id": "jqnOs",
+              "name": "benefitValue",
+              "fill": "#4CAF50",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "2x1 Gin Tonic",
+              "textAlign": "center",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 22,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "vtKfB",
+              "name": "timerFrame",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AYhbm",
+                  "name": "timerLabel",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "rBDzO",
+                      "name": "timerText",
+                      "fill": "#888888",
+                      "content": "VALID FOR",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "wY49h",
+                      "name": "timerCountdown",
+                      "fill": "#4CAF50",
+                      "content": "4:52 remaining",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NNSuL",
+                  "name": "timerTrack",
+                  "width": "fill_container",
+                  "height": 6,
+                  "fill": "#E0E0E0",
+                  "cornerRadius": 3,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "hN07q",
+                      "name": "timerBar",
+                      "width": 270,
+                      "height": 6,
+                      "fill": {
+                        "type": "gradient",
+                        "gradientType": "linear",
+                        "enabled": true,
+                        "rotation": 90,
+                        "size": {
+                          "height": 1
+                        },
+                        "colors": [
+                          {
+                            "color": "#4CAF50",
+                            "position": 0
+                          },
+                          {
+                            "color": "#2E7D32",
+                            "position": 1
+                          }
+                        ]
+                      },
+                      "cornerRadius": 3
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "8OrfN",
+      "x": 2762,
+      "y": -1391,
+      "name": "Mobile - Membership (Light)",
+      "clip": true,
+      "width": 402,
+      "height": 1100,
+      "fill": "#F5F5F5",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "pza9O",
+          "name": "mem-status",
+          "width": "fill_container",
+          "height": 62,
+          "fill": "#1A1A2E",
+          "padding": [
+            0,
+            20
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "nGBiB",
+              "name": "memTime",
+              "fill": "#FFFFFF",
+              "content": "9:41",
+              "fontFamily": "Inter",
+              "fontSize": 15,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "6BSu4",
+              "name": "memStatusIcons",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "5jIcO",
+                  "name": "msig",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "signal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "7FNdv",
+                  "name": "mbat",
+                  "width": 18,
+                  "height": 18,
+                  "iconFontName": "battery-full",
+                  "iconFontFamily": "lucide",
+                  "fill": "#FFFFFF"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "YEpHC",
+          "name": "memHeader",
+          "width": "fill_container",
+          "fill": "#FFFFFF",
+          "stroke": {
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "#E8E8E8"
+          },
+          "layout": "vertical",
+          "gap": 6,
+          "padding": [
+            20,
+            20,
+            16,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "PHSWR",
+              "name": "memHeaderLabel",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "id": "QuNzT",
+                  "name": "memAccentBar",
+                  "fill": "#D4AF37",
+                  "width": 3,
+                  "height": 14
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "oCquR",
+              "name": "memTitle",
+              "fill": "#1A1A2E",
+              "content": "CHOOSE YOUR ACCESS LEVEL",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 22,
+              "fontWeight": "700",
+              "letterSpacing": -0.5
+            },
+            {
+              "type": "text",
+              "id": "7A1a8",
+              "name": "memSubtitle",
+              "fill": "#777777",
+              "content": "Unlock exclusive Cusco nightlife benefits",
+              "fontFamily": "Space Grotesk",
+              "fontSize": 13
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Lp9W5",
+          "name": "cards-area",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            0,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "19xVe",
+              "name": "card1",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E8E8E8"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DftbU",
+                  "name": "c1top",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "AV8Q6",
+                      "name": "c1label",
+                      "fill": "#888888",
+                      "content": "ONE-TIME PAY",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "IkQFm",
+                      "name": "c1price",
+                      "fill": "#1A1A2E",
+                      "content": "S/9.90",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "k1GPa",
+                  "name": "c1name",
+                  "fill": "#1A1A2E",
+                  "content": "DISCOVERY PASS",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "iQSuA",
+                  "name": "c1benefit",
+                  "fill": "#888888",
+                  "content": "10 Tokens · Explore every venue type",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "MhK3S",
+                  "name": "l1b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "K61Ea",
+                      "name": "l1b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uQCSM",
+                      "name": "l1b1t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Specialty coffee + selected side",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "6ZUFW",
+                  "name": "l1b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "td6wK",
+                      "name": "l1b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "pNAuc",
+                      "name": "l1b2t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Dish from curated Discovery Menu",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NZ4ev",
+                  "name": "l1b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "cmQWv",
+                      "name": "l1b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "WOvgA",
+                      "name": "l1b3t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Signature cocktail or craft beer flight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "d7jeI",
+                  "name": "l1b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "l8uHB",
+                      "name": "l1b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "music-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "b82Bf",
+                      "name": "l1b4t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Cover fee + welcome drink included",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qC63Y",
+              "name": "card2",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 2,
+                "fill": "#D4AF37"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#D4AF3730",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 20
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZDYc0",
+                  "name": "c2topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QEa9h",
+                      "name": "c2badge",
+                      "fill": "#D4AF37",
+                      "cornerRadius": 4,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "pOMAY",
+                          "name": "c2badgeText",
+                          "fill": "#111111",
+                          "content": "RECOMMENDED",
+                          "fontFamily": "Space Grotesk",
+                          "fontSize": 9,
+                          "fontWeight": "700",
+                          "letterSpacing": 1
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "OMC6K",
+                      "name": "c2price",
+                      "fill": "#D4AF37",
+                      "content": "S/19.90/mo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "O58u7",
+                  "name": "c2name",
+                  "fill": "#1A1A2E",
+                  "content": "VIBE MEMBER",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "2BitU",
+                  "name": "c2sub",
+                  "fill": "#888888",
+                  "content": "MONTHLY SUBSCRIPTION",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 10,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "OlYVb",
+                  "name": "c2benefit",
+                  "fill": "#888888",
+                  "content": "15 Exploration Tokens / month",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "u6XMt",
+                  "name": "c2trial",
+                  "fill": "#D4AF3720",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zEFsw",
+                      "name": "c2trialText",
+                      "fill": "#D4AF37",
+                      "content": "1 MONTH FREE TRIAL",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "edhjs",
+                  "name": "l2b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0S61F",
+                      "name": "l2b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "cV6WQ",
+                      "name": "l2b1t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free upsize or small dessert with combo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xPdPk",
+                  "name": "l2b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "0gXeA",
+                      "name": "l2b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xAHsr",
+                      "name": "l2b2t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free appetizer or drink (Mon–Thu)",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "tQOU7",
+                  "name": "l2b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5e6Ub",
+                      "name": "l2b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "EkD6P",
+                      "name": "l2b3t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "2-for-1 cocktails until 9 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zAJmN",
+                  "name": "l2b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "rdH5M",
+                      "name": "l2b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "music-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#888888"
+                    },
+                    {
+                      "type": "text",
+                      "id": "G9vjS",
+                      "name": "l2b4t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Free entry ($0 cover) before midnight",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lGQSq",
+              "name": "card3",
+              "width": "fill_container",
+              "fill": "#FFFFFF",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#D4AF37"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Xd2px",
+                  "name": "c3topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "M1IXX",
+                      "name": "c3sub",
+                      "fill": "#D4AF37",
+                      "content": "MONTHLY SUBSCRIPTION",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "Vs81E",
+                      "name": "c3price",
+                      "fill": "#D4AF37",
+                      "content": "S/49.90/mo",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 22,
+                      "fontWeight": "700"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Dylfl",
+                  "name": "c3name",
+                  "fill": "#D4AF37",
+                  "content": "GOLD SELECT",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "7ZQNt",
+                  "name": "c3benefit",
+                  "fill": "#D4AF37",
+                  "content": "30 high-value Exploration Tokens / month",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "VH9fg",
+                  "name": "l3b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ejH2l",
+                      "name": "l3b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xQaiw",
+                      "name": "l3b1t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Table reservation + free Americano refill",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sgwDV",
+                  "name": "l3b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "kIKiD",
+                      "name": "l3b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "gZDrO",
+                      "name": "l3b2t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Waitlist priority + 1 free corkage/month",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oi2fu",
+                  "name": "l3b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "1dYjT",
+                      "name": "l3b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qHnDB",
+                      "name": "l3b3t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Flash Tastings + table reserved until 10 PM",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "3IVzn",
+                  "name": "l3b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "IjrBP",
+                      "name": "l3b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "zap",
+                      "iconFontFamily": "lucide",
+                      "fill": "#D4AF37"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qP7Sb",
+                      "name": "l3b4t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Fast-Pass entry + exclusive bar access",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EbKVD",
+              "name": "card4",
+              "width": "fill_container",
+              "fill": "#F0F0F0",
+              "cornerRadius": 4,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E0E0E0"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "j2AZI",
+                  "name": "c4topRow",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "TiOL4",
+                      "name": "c4sub",
+                      "fill": "#888888",
+                      "content": "INVITE ONLY / ANNUAL",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "CQk1O",
+                      "name": "c4inviteIcon",
+                      "width": 20,
+                      "height": 20,
+                      "iconFontName": "crown",
+                      "iconFontFamily": "lucide",
+                      "fill": "#1A1A2E"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Lz1rK",
+                  "name": "c4name",
+                  "fill": "#1A1A2E",
+                  "content": "BLACK FOUNDER",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 15,
+                  "fontWeight": "700",
+                  "letterSpacing": 0.5
+                },
+                {
+                  "type": "text",
+                  "id": "eGRk9",
+                  "name": "c4benefit",
+                  "fill": "#888888",
+                  "content": "All-Access Pass · No token limits",
+                  "fontFamily": "Space Grotesk",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "rqqv1",
+                  "name": "c4badge",
+                  "fill": "#E8E8E8",
+                  "cornerRadius": 4,
+                  "padding": [
+                    4,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "05RFP",
+                      "name": "c4badgeText",
+                      "fill": "#888888",
+                      "content": "APPLICATION REQUIRED",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 0.5
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UYFA1",
+                  "name": "l4b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "qEHfC",
+                      "name": "l4b1i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "coffee",
+                      "iconFontFamily": "lucide",
+                      "fill": "#555555"
+                    },
+                    {
+                      "type": "text",
+                      "id": "HStgy",
+                      "name": "l4b1t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Limited-edition beans + private event rates",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZMrEd",
+                  "name": "l4b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "eohmQ",
+                      "name": "l4b2i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "utensils",
+                      "iconFontFamily": "lucide",
+                      "fill": "#555555"
+                    },
+                    {
+                      "type": "text",
+                      "id": "shrLx",
+                      "name": "l4b2t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Chef&apos;s Table + exclusive tasting dinners",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Nn4KW",
+                  "name": "l4b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "vZjuc",
+                      "name": "l4b3i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "wine",
+                      "iconFontFamily": "lucide",
+                      "fill": "#555555"
+                    },
+                    {
+                      "type": "text",
+                      "id": "TCGgg",
+                      "name": "l4b3t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Personal liquor locker + premium glassware",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Bd7sD",
+                  "name": "l4b4",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hdRNS",
+                      "name": "l4b4i",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "crown",
+                      "iconFontFamily": "lucide",
+                      "fill": "#555555"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qHOsS",
+                      "name": "l4b4t",
+                      "fill": "#888888",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Skip line +2 guests · DJ access · VIP concierge",
+                      "fontFamily": "Space Grotesk",
+                      "fontSize": 11
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements SPEC-002: Vibe Feed — Lista de Locales.

Closes #2

## Changes

### Data Layer
- `VenueDTO.kt` — Firestore document model with `@DocumentId` and `@PropertyName` annotations
- `VenueMapper.kt` — `VenueDTO.toDomain()` extension function
- `VenueRemoteDataSource.kt` — Reads `venues` collection from Firestore
- `VenueRepositoryImpl.kt` — Implements domain `VenueRepository` interface

### Domain Layer
- `Venue.kt` — Clean domain model (no Firebase dependencies)
- `VenueRepository.kt` — Interface with `getVenues()` and `getVenueById()`
- `GetVenuesUseCase.kt` — Single-responsibility use case

### Feature Layer (MVI)
- `State.kt`, `Event.kt`, `VenueUiModel.kt` — MVI primitives
- `VibeFeedViewModel.kt` — Loads venues, requests location permission, calculates Haversine distance, emits NavigateToDetail side effect
- `VibeFeedScreen.kt` — VerticalPager with full-screen AsyncImage, dark gradient overlay, BottomNavBar, location permission launcher
- `VenueOverlay.kt` — Venue name, distance, OPEN NOW badge, gold benefit text
- `SideActions.kt` — Heart (2.4K), Share, Save icons

### DesignSystem
- `BottomNavBar.kt` — Material3 NavigationBar with FEED/EXPLORE/PASSES/PROFILE tabs, FEED tab highlighted in gold

### Navigation
- Updated `AppNavHost.kt` with `VibeFeedScreen`, `VenueDetailRoute(venueId)`, and placeholder routes for EXPLORE, PASSES, PROFILE
- Added `ExploreScreen`, `PassesScreen`, `ProfileScreen`, `VenueDetailPlaceholderScreen`

### Resources
- Added ES + EN strings for all feed UI elements
- Added `ACCESS_FINE_LOCATION` & `ACCESS_COARSE_LOCATION` permissions to AndroidManifest

### Dependencies
- `coil-compose:2.7.0` — Image loading
- `play-services-location:21.3.0` — GPS distance calculation
- `mockk:1.13.10` + `coroutines-test:1.8.1` — Testing

## Tests
- `VenueMapperTest.kt` — 5 unit tests covering all field mappings and edge cases
- `GetVenuesUseCaseTest.kt` — 4 unit tests (success, failure, empty list, verify call count)
- `./gradlew assembleDebug` ✅ BUILD SUCCESSFUL
- `./gradlew testDebugUnitTest` ✅ BUILD SUCCESSFUL

## Notes
- T-002.1 (Firestore seed) must be done manually in Firebase Console with 3-5 venue documents
- Venue detail screen is a placeholder — will be implemented in SPEC-003